### PR TITLE
Added implementation inheritance

### DIFF
--- a/examples/dom_example.re
+++ b/examples/dom_example.re
@@ -2,12 +2,75 @@ open ReasonJs;
 
 /* Adapted from https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Examples#Example_7:_Displaying_Event_Object_Properties */
 
-open Document;
-open Element;
+
+/* Option.map */
+let map f => fun
+| Some v => Some (f v)
+| None => None;
+
+let and_then f => fun
+| Some v => f v
+| None => None;
+
+let unwrapUnsafely = fun
+| Some v => v
+| None => assert false;
+
+
+/*
+ * These SHOULD type check
+ */
+document
+  |> Document.createElement "div"
+  |> Element.className;
 
 document
-  |> createElement "div"
-  |> className;
+  |> Document.createElement "div"
+  |> Element.nextElementSibling
+  |> map Element.innerText; /* innerText is a function that accepts a Node */
+
+document
+  |> Document.createElement "div"
+  |> Element.asNode
+  |> Node.parentElement /* inherited from Node, returns DomRe.element */
+  |> map Element.innerText; /* inherited from Node */
+
+let el = document
+  |> Document.createElement "div"
+  |> Element.asHtmlElement
+  |> unwrapUnsafely;
+
+/*
+document
+  |> Document.asHtmlDocument
+  |> and_then HtmlDocument.body
+  |> map (Element.appendChild el);
+*/
+document
+  |> Document.asHtmlDocument
+  |> and_then HtmlDocument.body
+  |> map (Element.appendChild (el |> HtmlElement.asNode));
+
+
+/*
+/*
+ * These MAY fail type check
+ */
+ document
+   |> Document.createElement "div"
+   |> Element.nextElementSibling
+   |> map Node.innerText;
+
+
+/*
+ * These SHOULD NOT type check
+ */
+document
+  |> Document.createElement "div"
+  |> Element.asNode
+  |> Element.parentElement; /* inherited from Node, returns DomRe.element */
+*/
+
 
 /*
 /* ideal, but requires piped setters */

--- a/examples/dom_example.re
+++ b/examples/dom_example.re
@@ -60,8 +60,6 @@ document
    |> Document.createElement "div"
    |> Element.nextElementSibling
    |> map Node.innerText;
-
-
 /*
  * These SHOULD NOT type check
  */
@@ -74,7 +72,6 @@ document
 
 /*
 /* ideal, but requires piped setters */
-
 switch (document |> body) {
   | Some body =>
     document

--- a/src/dom/cssStyleDeclarationRe.re
+++ b/src/dom/cssStyleDeclarationRe.re
@@ -8,6 +8,7 @@ external parentRule : t => cssRule = "" [@@bs.get];
 
 external getPropertyPriority : string => string = "" [@@bs.send.pipe: t];
 external getPropertyValue : string => string = "" [@@bs.send.pipe: t];
+
 external item : int => string = "" [@@bs.send.pipe: t];
 external removeProperty : string => string = "" [@@bs.send.pipe: t];
 external setProperty : string => string => string => unit = "" [@@bs.send.pipe: t];

--- a/src/dom/cssStyleDeclarationRe.re
+++ b/src/dom/cssStyleDeclarationRe.re
@@ -1,4 +1,5 @@
 type t = DomRe.cssStyleDeclaration;
+type cssRule; /* TODO: Move to DomRe */
 
 external cssText : t => string = "" [@@bs.get];
 external setCssText : t => string => unit = "cssText" [@@bs.set];

--- a/src/dom/cssStyleDeclarationRe.re
+++ b/src/dom/cssStyleDeclarationRe.re
@@ -7,7 +7,6 @@ external parentRule : t => cssRule = "" [@@bs.get];
 
 external getPropertyPriority : string => string = "" [@@bs.send.pipe: t];
 external getPropertyValue : string => string = "" [@@bs.send.pipe: t];
-
 external item : int => string = "" [@@bs.send.pipe: t];
 external removeProperty : string => string = "" [@@bs.send.pipe: t];
 external setProperty : string => string => string => unit = "" [@@bs.send.pipe: t];

--- a/src/dom/cssStyleDeclarationRe.re
+++ b/src/dom/cssStyleDeclarationRe.re
@@ -1,5 +1,4 @@
 type t = DomRe.cssStyleDeclaration;
-type cssRule; /* TODO: move to DomRe */
 
 external cssText : t => string = "" [@@bs.get];
 external setCssText : t => string => unit = "cssText" [@@bs.set];
@@ -12,7 +11,7 @@ external getPropertyValue : string => string = "" [@@bs.send.pipe: t];
 external item : int => string = "" [@@bs.send.pipe: t];
 external removeProperty : string => string = "" [@@bs.send.pipe: t];
 external setProperty : string => string => string => unit = "" [@@bs.send.pipe: t];
-external setPropertyValue : string => string => unit = "" [@@bs.send.pipe: t];
+/*external setPropertyValue : string => string => unit = "" [@@bs.send.pipe: t];*/ /* not mentioned by MDN and not implemented by chrome, but in the CSSOM spec:  https://drafts.csswg.org/cssom/#the-cssstyledeclaration-interface */
 
 /* CSS2Properties */
 external azimuth : t => string = "" [@@bs.get];

--- a/src/dom/documentRe.re
+++ b/src/dom/documentRe.re
@@ -1,102 +1,108 @@
-type t = DomRe.document;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_document = Type.t;
 
-external asNode : t => DomRe.node = "%identity";
-external asEventTarget : t => DomRe.eventTarget = "%identity";
-let asHtmlDocument : t => Js.null DomRe.htmlDocument = [%bs.raw {|
-  function (document) {
-    return document.doctype.name === "html" ?  document : null;
-  }
-|}];
-let asHtmlDocument : t => option DomRe.htmlDocument = fun self => Js.Null.to_opt (asHtmlDocument self);
+  external asDocument : t_document => DomRe.document = "%identity";
 
-let ofNode node: option t =>
-  (NodeRe.nodeType node) == Document ? Some (DomRe.cast node) : None;
+  let asHtmlDocument : t_document => Js.null DomRe.htmlDocument = [%bs.raw {|
+    function (document) {
+      return document.doctype.name === "html" ?  document : null;
+    }
+  |}];
+  let asHtmlDocument : t_document => option DomRe.htmlDocument = fun self => Js.Null.to_opt (asHtmlDocument self);
 
-type compatMode =
-| BackCompat
-| CSS1Compat
-| Unknown;
-let decodeCompatMode = fun /* internal */
-| "BackCompat" => BackCompat
-| "CSS1Compat" => CSS1Compat
-| _            => Unknown;
+  let ofNode node: option t_document =>
+    (NodeRe.nodeType node) == Document ? Some (DomInternalRe.cast node) : None;
 
-type visibilityState =
-| Visible
-| Hidden
-| Prerender
-| Unloaded
-| Unknown;
-let decodeVisibilityState = fun /* internal */
-| "visible"   => Visible
-| "hidden"    => Hidden
-| "prerender" => Prerender
-| "unloaded"  => Unloaded
-| _           => Unknown;
+  type compatMode =
+  | BackCompat
+  | CSS1Compat
+  | Unknown;
+  let decodeCompatMode = fun /* internal */
+  | "BackCompat" => BackCompat
+  | "CSS1Compat" => CSS1Compat
+  | _            => Unknown;
 
-external characterSet : t => string = "" [@@bs.get];
-external compatMode : t => string /* compatMode enum */ = "" [@@bs.get]; /* experimental */
-let compatMode : t => compatMode = fun self => decodeCompatMode (compatMode self);
-external docType : t => DomRe.documentType = "" [@@bs.get];
-external documentElement : t => DomRe.element = "" [@@bs.get];
-external documentURI : t => string = "" [@@bs.get];
-external hidden : t => Js.boolean = "" [@@bs.get];
-let hidden : t => bool = fun v => Js.to_bool (hidden v);
-external implementation : t => DomRe.documentImplementation = "" [@@bs.get];
-external lastStyleSheetSet : t => string = "" [@@bs.get];
-external pointerLockElement : t => Js.null DomRe.element = "" [@@bs.get]; /* experimental */
-let pointerLockElement : t => option DomRe.element = fun self => Js.Null.to_opt (pointerLockElement self);
-external preferredStyleSheetSet : t => string = "" [@@bs.get];
-external scrollingElement : t => Js.null DomRe.element = "" [@@bs.get];
-let scrollingElement : t => option DomRe.element = fun self => Js.Null.to_opt (scrollingElement self);
-external selectedStyleSheetSet : t => string = "" [@@bs.get];
-external setSelectedStyleSheetSet : t => string => unit = "selectedStyleSheetSet" [@@bs.set];
-external styleSheets : t => array DomRe.cssStyleSheet = "" [@@bs.get]; /* return StyleSheetList, not array */
-external styleSheetSets : t => array string = "" [@@bs.get];
-external visibilityState : t => string /* visibilityState enum */ = "" [@@bs.get];
-let visibilityState : t => visibilityState = fun self => decodeVisibilityState (visibilityState self);
+  type visibilityState =
+  | Visible
+  | Hidden
+  | Prerender
+  | Unloaded
+  | Unknown;
+  let decodeVisibilityState = fun /* internal */
+  | "visible"   => Visible
+  | "hidden"    => Hidden
+  | "prerender" => Prerender
+  | "unloaded"  => Unloaded
+  | _           => Unknown;
 
-external adoptNode : DomRe.element => DomRe.element = "" [@@bs.send.pipe: t];
-external createAttribute : string => DomRe.attr = "" [@@bs.send.pipe: t];
-external createAttributeNS : string => string => DomRe.attr = "" [@@bs.send.pipe: t];
-external createComment : string => DomRe.comment = "" [@@bs.send.pipe: t];
-external createDocumentFragment : DomRe.documentFragment = "" [@@bs.send.pipe: t];
-external createElement : string => DomRe.element = "" [@@bs.send.pipe: t];
-external createElementWithOptions : string => Js.t {..} => DomRe.element = "createElement" [@@bs.send.pipe: t]; /* not widely supported */
-external createElementNS : string => string => DomRe.element = "" [@@bs.send.pipe: t];
-external createElementNSWithOptions : string => string => Js.t {..} => DomRe.element = "createEementNS" [@@bs.send.pipe: t]; /* not widely supported */
-external createEvent : string /* large enum */ => DomRe.event = "" [@@bs.send.pipe: t]; /* discouraged (but not deprecated) in favor of Event constructors */
-external createNodeIterator : DomRe.node => DomRe.nodeIterator = "" [@@bs.send.pipe: t];
-external createNodeIteratorWithWhatToShow : DomRe.node => NodeFilterRe.WhatToShow.t => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t];
-external createNodeIteratorWithWhatToShowFilter : DomRe.node => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t];
-/* createProcessingInstruction */
-external createRange : DomRe.range = "" [@@bs.send.pipe: t];
-external createText : string => DomRe.textNode = "" [@@bs.send.pipe: t];
-external createTreeWalker : DomRe.element => DomRe.treeWalker = "" [@@bs.send.pipe: t];
-external createTreeWalkerWithWhatToShow : DomRe.element => NodeFilterRe.WhatToShow.t => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t];
-external createTreeWalkerWithWhatToShowFilter : DomRe.element => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t];
-external elementFromPoint : int => int => DomRe.element = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-external elementsFromPoint : int => int => array DomRe.element = "" [@@bs.send.pipe: t]; /* experimental */
-external enableStyleSheetsForSet : string => unit = "" [@@bs.send.pipe: t];
-external exitPointerLock : unit = "" [@@bs.send.pipe: t]; /* experimental */
-external getAnimations : array DomRe.animation = "" [@@bs.send.pipe: t]; /* experimental */
-external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external importNode : DomRe.element => DomRe.element = "" [@@bs.send.pipe: t];
-external importNodeDeep : DomRe.element => Js.boolean => DomRe.element = "importNode" [@@bs.send.pipe: t];
-let importNodeDeep : DomRe.element => t => DomRe.element = fun element self => importNodeDeep element (Js.Boolean.to_js_boolean true) self;
-external registerElement : string => (unit => DomRe.element) = "" [@@bs.send.pipe: t]; /* experimental and deprecated in favor of customElements.define() */
-external registerElementWithOptions : string => Js.t {..} => (unit => DomRe.element) = "registerElement" [@@bs.send.pipe: t]; /* experimental and deprecated in favor of customElements.define() */
-external getElementById : string => Js.null DomRe.element = "" [@@bs.send.pipe: t];
-let getElementById : string => t => option DomRe.element = fun id self => Js.Null.to_opt (getElementById id self);
-external querySelector : string => Js.null DomRe.element = "" [@@bs.send.pipe: t];
-let querySelector : string => t => option DomRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
-external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t];
+  external characterSet : t_document => string = "" [@@bs.get];
+  external compatMode : t_document => string /* compatMode enum */ = "" [@@bs.get]; /* experimental */
+  let compatMode : t_document => compatMode = fun self => decodeCompatMode (compatMode self);
+  external docType : t_document => DomRe.documentType = "" [@@bs.get];
+  external documentElement : t_document => DomRe.element = "" [@@bs.get];
+  external documentURI : t_document => string = "" [@@bs.get];
+  external hidden : t_document => Js.boolean = "" [@@bs.get];
+  let hidden : t_document => bool = fun v => Js.to_bool (hidden v);
+  external implementation : t_document => DomRe.documentImplementation = "" [@@bs.get];
+  external lastStyleSheetSet : t_document => string = "" [@@bs.get];
+  external pointerLockElement : t_document => Js.null DomRe.element = "" [@@bs.get]; /* experimental */
+  let pointerLockElement : t_document => option DomRe.element = fun self => Js.Null.to_opt (pointerLockElement self);
+  external preferredStyleSheetSet : t_document => string = "" [@@bs.get];
+  external scrollingElement : t_document => Js.null DomRe.element = "" [@@bs.get];
+  let scrollingElement : t_document => option DomRe.element = fun self => Js.Null.to_opt (scrollingElement self);
+  external selectedStyleSheetSet : t_document => string = "" [@@bs.get];
+  external setSelectedStyleSheetSet : t_document => string => unit = "selectedStyleSheetSet" [@@bs.set];
+  external styleSheets : t_document => array DomRe.cssStyleSheet = "" [@@bs.get]; /* return StyleSheetList, not array */
+  external styleSheetSets : t_document => array string = "" [@@bs.get];
+  external visibilityState : t_document => string /* visibilityState enum */ = "" [@@bs.get];
+  let visibilityState : t_document => visibilityState = fun self => decodeVisibilityState (visibilityState self);
 
-/** XPath stuff */
-/* createExpression */
-/* createNSResolver */
-/* evaluate */
+  external adoptNode : DomRe.element => DomRe.element = "" [@@bs.send.pipe: t_document];
+  external createAttribute : string => DomRe.attr = "" [@@bs.send.pipe: t_document];
+  external createAttributeNS : string => string => DomRe.attr = "" [@@bs.send.pipe: t_document];
+  external createComment : string => DomRe.comment = "" [@@bs.send.pipe: t_document];
+  external createDocumentFragment : DomRe.documentFragment = "" [@@bs.send.pipe: t_document];
+  external createElement : string => DomRe.element = "" [@@bs.send.pipe: t_document];
+  external createElementWithOptions : string => Js.t {..} => DomRe.element = "createElement" [@@bs.send.pipe: t_document]; /* not widely supported */
+  external createElementNS : string => string => DomRe.element = "" [@@bs.send.pipe: t_document];
+  external createElementNSWithOptions : string => string => Js.t {..} => DomRe.element = "createEementNS" [@@bs.send.pipe: t_document]; /* not widely supported */
+  external createEvent : string /* large enum */ => DomRe.event = "" [@@bs.send.pipe: t_document]; /* discouraged (but not deprecated) in favor of Event constructors */
+  external createNodeIterator : DomRe.node => DomRe.nodeIterator = "" [@@bs.send.pipe: t_document];
+  external createNodeIteratorWithWhatToShow : DomRe.node => NodeFilterRe.WhatToShow.t => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
+  external createNodeIteratorWithWhatToShowFilter : DomRe.node => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
+  /* createProcessingInstruction */
+  external createRange : DomRe.range = "" [@@bs.send.pipe: t_document];
+  external createText : string => DomRe.textNode = "" [@@bs.send.pipe: t_document];
+  external createTreeWalker : DomRe.element => DomRe.treeWalker = "" [@@bs.send.pipe: t_document];
+  external createTreeWalkerWithWhatToShow : DomRe.element => NodeFilterRe.WhatToShow.t => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
+  external createTreeWalkerWithWhatToShowFilter : DomRe.element => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
+  external elementFromPoint : int => int => DomRe.element = "" [@@bs.send.pipe: t_document]; /* experimental, but widely supported */
+  external elementsFromPoint : int => int => array DomRe.element = "" [@@bs.send.pipe: t_document]; /* experimental */
+  external enableStyleSheetsForSet : string => unit = "" [@@bs.send.pipe: t_document];
+  external exitPointerLock : unit = "" [@@bs.send.pipe: t_document]; /* experimental */
+  external getAnimations : array DomRe.animation = "" [@@bs.send.pipe: t_document]; /* experimental */
+  external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external importNode : DomRe.element => DomRe.element = "" [@@bs.send.pipe: t_document];
+  external importNodeDeep : DomRe.element => Js.boolean => DomRe.element = "importNode" [@@bs.send.pipe: t_document];
+  let importNodeDeep : DomRe.element => t_document => DomRe.element = fun element self => importNodeDeep element (Js.Boolean.to_js_boolean true) self;
+  external registerElement : string => (unit => DomRe.element) = "" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
+  external registerElementWithOptions : string => Js.t {..} => (unit => DomRe.element) = "registerElement" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
+  external getElementById : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_document];
+  let getElementById : string => t_document => option DomRe.element = fun id self => Js.Null.to_opt (getElementById id self);
+  external querySelector : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_document];
+  let querySelector : string => t_document => option DomRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
+  external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t_document];
 
-/* GlobalEventHandlers interface */
+  /** XPath stuff */
+  /* createExpression */
+  /* createNSResolver */
+  /* evaluate */
+
+  /* GlobalEventHandlers interface */
+};
+
+include NodeRe.Impl { type t = DomRe.document };
+include EventTargetRe.Impl { type t = DomRe.document };
+include Impl { type t = DomRe.document };

--- a/src/dom/domInternalRe.re
+++ b/src/dom/domInternalRe.re
@@ -1,0 +1,6 @@
+
+external cast : 'a => 'b = "%identity"; /* internal */
+
+module type Type = {
+  type t;
+};

--- a/src/dom/domRe.re
+++ b/src/dom/domRe.re
@@ -47,5 +47,3 @@ let decodeDir = fun /* internal */
 | "ltr" => Ltr
 | "rtl" => Rtl
 | _     => Unknown;
-
-external cast : 'a => 'b = "%identity"; /* internal */

--- a/src/dom/elementRe.re
+++ b/src/dom/elementRe.re
@@ -1,109 +1,124 @@
-type t = DomRe.element;
+module Impl(Type: DomInternalRe.Type) => {
+  type t_element = Type.t;
 
-external asNode : t => DomRe.node = "%identity";
-external asEventTarget : t => DomRe.eventTarget = "%identity";
-let asHtmlElement : t => Js.null DomRe.htmlElement = [%bs.raw {|
-  function (element) {
-    // BEWARE: Assumes "contentEditable" uniquely identifies an HTMLELement
-    return element.contentEditable !== undefined ?  element : null;
-  }
-|}];
-let asHtmlElement : t => option DomRe.htmlElement = fun self => Js.Null.to_opt (asHtmlElement self);
+  external asElement : t_element => DomRe.element = "%identity";
 
-let ofNode node: option t =>
-  (NodeRe.nodeType node) == Element ? Some (DomRe.cast node) : None;
+  let asHtmlElement : t_element => Js.null DomRe.htmlElement = [%bs.raw {|
+    function (element) {
+      // BEWARE: Assumes "contentEditable" uniquely identifies an HTMLELement
+      return element.contentEditable !== undefined ?  element : null;
+    }
+  |}];
+  let asHtmlElement : t_element => option DomRe.htmlElement = fun self => Js.Null.to_opt (asHtmlElement self);
 
-type insertPosition =
-| BeforeBegin
-| AfterBegin
-| BeforeEnd
-| AfterEnd;
-let encodeInsertPosition = fun /* internal */
-| BeforeBegin => "beforebegin"
-| AfterBegin  => "afterbegin"
-| BeforeEnd   => "beforeemd"
-| AfterEnd    => "afterend";
+  let ofNode node: option t_element =>
+    (NodeRe.nodeType node) == Element ? Some (DomInternalRe.cast node) : None;
 
-external assignedSlot : t => t = "" [@@bs.get]; /* experimental, returns HTMLSlotElement */
-external attributes : t => array DomRe.attr = "" [@@bs.get]; /* return NameNodeMap, not array */
-external classList : t => DomRe.domTokenList = "" [@@bs.get];
-external className : t => string = "" [@@bs.get];
-external setClassName : t => string => unit = "className" [@@bs.set];
-external clientHeight : t => int = "" [@@bs.get]; /* experimental */
-external clientLeft : t => int = "" [@@bs.get]; /* experimental */
-external clientTop : t => int = "" [@@bs.get]; /* experimental */
-external clientWidth : t => int = "" [@@bs.get]; /* experimental */
-external id : t => string = "" [@@bs.get];
-external setId : t => string => unit = "id" [@@bs.set];
-external innerHTML : t => string = "" [@@bs.get];
-external setInnerHTML : t => string => unit = "innerHTML" [@@bs.set];
-external localName : t => string = "" [@@bs.get];
-external namespaceURI : t => Js.null string = "" [@@bs.get];
-let namespaceURI : t => option string = fun self => Js.Null.to_opt (namespaceURI self);
-external nextElementSibling : t => Js.null t = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
-let nextElementSibling : t => option t = fun self => Js.Null.to_opt (nextElementSibling self);
-external outerHTML : t => string = "" [@@bs.get]; /* experimental, but widely supported */
-external setOuterHTML : t => string => unit = "outerHTML" [@@bs.set]; /* experimental, but widely supported */
-external prefix : t => Js.null string = "" [@@bs.get];
-let prefix : t => option string = fun self => Js.Null.to_opt (prefix self);
-external previousElementSibling : t => Js.null t = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
-let previousElementSibling : t => option t = fun self => Js.Null.to_opt (previousElementSibling self);
-external scrollHeight : t => int = "" [@@bs.get]; /* experimental, but widely supported */
-external scrollLeft : t => int = "" [@@bs.get]; /* experimental */
-external setScrollLeft : t => int => unit = "scrollLeft" [@@bs.set]; /* experimental */
-external scrollTop : t => int = "" [@@bs.get]; /* experimental, but widely supported */
-external setScrollTop : t => int => unit = "scrollTop" [@@bs.set]; /* experimental, but widely supported */
-external scrollWidth : t => int = "" [@@bs.get]; /* experimental */
-external shadowRoot : t => t = "" [@@bs.get]; /* experimental */
-external slot : t => string = "" [@@bs.get]; /* experimental */
-external setSlot : t => string => unit = "slot" [@@bs.set]; /* experimental */
-external tagName : t => string = "" [@@bs.get];
+  type insertPosition =
+  | BeforeBegin
+  | AfterBegin
+  | BeforeEnd
+  | AfterEnd;
+  let encodeInsertPosition = fun /* internal */
+  | BeforeBegin => "beforebegin"
+  | AfterBegin  => "afterbegin"
+  | BeforeEnd   => "beforeemd"
+  | AfterEnd    => "afterend";
 
-external attachShadow : Js.t {..} => DomRe.shadowRoot  = "" [@@bs.send.pipe: t]; /* experimental */
-external animate : Js.t {..} => Js.t {..} => DomRe.animation = "" [@@bs.send.pipe: t]; /* experimental */
-external closest : string => t = "" [@@bs.send.pipe: t]; /* experimental */
-external createShadowRoot : DomRe.shadowRoot = "" [@@bs.send.pipe: t]; /* experimental AND deprecated (?!) */
-external getAttribute : string => Js.null string = "" [@@bs.send.pipe: t];
-let getAttribute : string => t => option string = fun name self => Js.Null.to_opt (getAttribute name self);
-external getAttributeNS : string => string => Js.null string = "" [@@bs.send.pipe: t];
-let getAttributeNS : string => string => t => option string = fun ns name self => Js.Null.to_opt (getAttributeNS ns name self);
-external getBoundingClientRect : DomRe.domRect = "" [@@bs.send.pipe: t];
-external getClientRects : array DomRe.domRect = "" [@@bs.send.pipe: t];
-external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t];
-external hasAttribute : string => Js.boolean = "" [@@bs.send.pipe: t];
-let hasAttribute : string => t => bool = fun name self => Js.to_bool (hasAttribute name self);
-external hasAttributeNS : string => string => Js.boolean = "" [@@bs.send.pipe: t];
-let hasAttributeNS : string => string => t => bool = fun ns name self => Js.to_bool (hasAttributeNS ns name self);
-external hasAttributes : Js.boolean = "" [@@bs.send.pipe: t];
-let hasAttributes : t => bool = fun self => Js.to_bool (hasAttributes self);
-external insertAdjacentElement : string /* insertPosition enum */ => t => unit = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-let insertAdjacentElement : insertPosition => t => t => unit = fun position element self => insertAdjacentElement (encodeInsertPosition position) element self;
-external insertAdjacentHTML : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-let insertAdjacentHTML : insertPosition => string => t => unit = fun position text self => insertAdjacentHTML (encodeInsertPosition position) text self;
-external insertAdjacentText : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-let insertAdjacentText : insertPosition => string => t => unit = fun position text self => insertAdjacentText (encodeInsertPosition position) text self;
-external matches : string => Js.boolean = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-let matches : string => t => bool = fun selector self => Js.to_bool (matches selector self);
-external querySelector : string => Js.null t = "" [@@bs.send.pipe: t];
-let querySelector : string => t => option t = fun selector self => Js.Null.to_opt (querySelector selector self);
-external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t];
-external releasePointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t];
-external remove : unit = "" [@@bs.send.pipe: t]; /* experimental */
-external removeAttribute : string => unit = "" [@@bs.send.pipe: t];
-external removeAttributeNS : string => string => unit = "" [@@bs.send.pipe: t];
-external requestFullscreen : unit = "" [@@bs.send.pipe: t]; /* experimental */
-external requestPointerLock : unit = "" [@@bs.send.pipe: t]; /* experimental */
-external scrollIntoView : unit = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-external scrollIntoViewNoAlignToTop : Js.boolean => unit = "scrollIntoView" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-let scrollIntoViewNoAlignToTop : t => unit = fun self => scrollIntoViewNoAlignToTop (Js.Boolean.to_js_boolean true) self;
-external scrollIntoViewWithOptions : Js.t {..} => unit = "scrollIntoView" [@@bs.send.pipe: t]; /* experimental */
-external setAttribute : string => string => unit = "" [@@bs.send.pipe: t];
-external setAttributeNS : string => string => string => unit = "" [@@bs.send.pipe: t];
-external setPointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t];
+  external assignedSlot : t_element => DomRe.element = "" [@@bs.get]; /* experimental, returns HTMLSlotElement */
+  external attributes : t_element => array DomRe.attr = "" [@@bs.get]; /* return NameNodeMap, not array */
+  external classList : t_element => DomRe.domTokenList = "" [@@bs.get];
+  external className : t_element => string = "" [@@bs.get];
+  external setClassName : t_element => string => unit = "className" [@@bs.set];
+  external clientHeight : t_element => int = "" [@@bs.get]; /* experimental */
+  external clientLeft : t_element => int = "" [@@bs.get]; /* experimental */
+  external clientTop : t_element => int = "" [@@bs.get]; /* experimental */
+  external clientWidth : t_element => int = "" [@@bs.get]; /* experimental */
+  external id : t_element => string = "" [@@bs.get];
+  external setId : t_element => string => unit = "id" [@@bs.set];
+  external innerHTML : t_element => string = "" [@@bs.get];
+  external setInnerHTML : t_element => string => unit = "innerHTML" [@@bs.set];
+  external localName : t_element => string = "" [@@bs.get];
+  external namespaceURI : t_element => Js.null string = "" [@@bs.get];
+  let namespaceURI : t_element => option string = fun self => Js.Null.to_opt (namespaceURI self);
+  external nextElementSibling : t_element => Js.null DomRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
+  let nextElementSibling : t_element => option DomRe.element = fun self => Js.Null.to_opt (nextElementSibling self);
+  external outerHTML : t_element => string = "" [@@bs.get]; /* experimental, but widely supported */
+  external setOuterHTML : t_element => string => unit = "outerHTML" [@@bs.set]; /* experimental, but widely supported */
+  external prefix : t_element => Js.null string = "" [@@bs.get];
+  let prefix : t_element => option string = fun self => Js.Null.to_opt (prefix self);
+  external previousElementSibling : t_element => Js.null DomRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
+  let previousElementSibling : t_element => option DomRe.element = fun self => Js.Null.to_opt (previousElementSibling self);
+  external scrollHeight : t_element => int = "" [@@bs.get]; /* experimental, but widely supported */
+  external scrollLeft : t_element => int = "" [@@bs.get]; /* experimental */
+  external setScrollLeft : t_element => int => unit = "scrollLeft" [@@bs.set]; /* experimental */
+  external scrollTop : t_element => int = "" [@@bs.get]; /* experimental, but widely supported */
+  external setScrollTop : t_element => int => unit = "scrollTop" [@@bs.set]; /* experimental, but widely supported */
+  external scrollWidth : t_element => int = "" [@@bs.get]; /* experimental */
+  external shadowRoot : t_element => DomRe.element = "" [@@bs.get]; /* experimental */
+  external slot : t_element => string = "" [@@bs.get]; /* experimental */
+  external setSlot : t_element => string => unit = "slot" [@@bs.set]; /* experimental */
+  external tagName : t_element => string = "" [@@bs.get];
 
-/* GlobalEventHandlers interface */
-/* Not sure this should be exposed, since EventTarget seems like a better API */
+  external attachShadow : Js.t {..} => DomRe.shadowRoot  = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external animate : Js.t {..} => Js.t {..} => DomRe.animation = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external closest : string => DomRe.element = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external createShadowRoot : DomRe.shadowRoot = "" [@@bs.send.pipe: t_element]; /* experimental AND deprecated (?!) */
+  external getAttribute : string => Js.null string = "" [@@bs.send.pipe: t_element];
+  let getAttribute : string => t_element => option string = fun name self => Js.Null.to_opt (getAttribute name self);
+  external getAttributeNS : string => string => Js.null string = "" [@@bs.send.pipe: t_element];
+  let getAttributeNS : string => string => t_element => option string = fun ns name self => Js.Null.to_opt (getAttributeNS ns name self);
+  external getBoundingClientRect : DomRe.domRect = "" [@@bs.send.pipe: t_element];
+  external getClientRects : array DomRe.domRect = "" [@@bs.send.pipe: t_element];
+  external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external hasAttribute : string => Js.boolean = "" [@@bs.send.pipe: t_element];
+  let hasAttribute : string => t_element => bool = fun name self => Js.to_bool (hasAttribute name self);
+  external hasAttributeNS : string => string => Js.boolean = "" [@@bs.send.pipe: t_element];
+  let hasAttributeNS : string => string => t_element => bool = fun ns name self => Js.to_bool (hasAttributeNS ns name self);
+  external hasAttributes : Js.boolean = "" [@@bs.send.pipe: t_element];
+  let hasAttributes : t_element => bool = fun self => Js.to_bool (hasAttributes self);
+  external insertAdjacentElement : string /* insertPosition enum */ => DomRe.element => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let insertAdjacentElement : insertPosition => DomRe.element => t_element => unit = fun position element self => insertAdjacentElement (encodeInsertPosition position) element self;
+  external insertAdjacentHTML : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let insertAdjacentHTML : insertPosition => string => t_element => unit = fun position text self => insertAdjacentHTML (encodeInsertPosition position) text self;
+  external insertAdjacentText : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let insertAdjacentText : insertPosition => string => t_element => unit = fun position text self => insertAdjacentText (encodeInsertPosition position) text self;
+  external matches : string => Js.boolean = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let matches : string => t_element => bool = fun selector self => Js.to_bool (matches selector self);
+  external querySelector : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_element];
+  let querySelector : string => t_element => option DomRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
+  external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t_element];
+  external releasePointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
+  external remove : unit = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external removeAttribute : string => unit = "" [@@bs.send.pipe: t_element];
+  external removeAttributeNS : string => string => unit = "" [@@bs.send.pipe: t_element];
+  external requestFullscreen : unit = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external requestPointerLock : unit = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external scrollIntoView : unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  external scrollIntoViewNoAlignToTop : Js.boolean => unit = "scrollIntoView" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let scrollIntoViewNoAlignToTop : t_element => unit = fun self => scrollIntoViewNoAlignToTop (Js.Boolean.to_js_boolean true) self;
+  external scrollIntoViewWithOptions : Js.t {..} => unit = "scrollIntoView" [@@bs.send.pipe: t_element]; /* experimental */
+  external setAttribute : string => string => unit = "" [@@bs.send.pipe: t_element];
+  external setAttributeNS : string => string => string => unit = "" [@@bs.send.pipe: t_element];
+  external setPointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
 
-external setOnClick : t => (DomRe.event => unit) => unit = "onclick" [@@bs.set]; /* should be MouseEvent */
+  /* GlobalEventHandlers interface */
+  /* Not sure this should be exposed, since EventTarget seems like a better API */
+
+  external setOnClick : t_element => (DomRe.event => unit) => unit = "onclick" [@@bs.set]; /* should be MouseEvent */
+};
+/* TODO: This doesnæt work. Why?
+module Tree (Type: DomInternalRe.Type) => {
+  include NodeRe.Impl { type t = Type };
+  include EventTargetRe.Impl { type t = Type };
+  include Impl { type t = Type };
+};
+
+include Tree { type t = DomRe.element };
+*/
+
+include NodeRe.Impl { type t = DomRe.element };
+include EventTargetRe.Impl { type t = DomRe.element };
+include Impl { type t = DomRe.element };

--- a/src/dom/eventTargetRe.re
+++ b/src/dom/eventTargetRe.re
@@ -1,11 +1,17 @@
-type t = DomRe.eventTarget;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_eventtarget = Type.t;
 
-external addEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t];
-external addEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "addEventListener" [@@bs.send.pipe: t]; /* not widely supported */
-external addEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "addEventListener" [@@bs.send.pipe: t];
-let addEventListenerUseCapture : string => (DomRe.event => unit) => t => unit = fun type_ listener self => addEventListenerUseCapture type_ listener (Js.Boolean.to_js_boolean true) self;
-external removeEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t];
-external removeEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "removeEventListener" [@@bs.send.pipe: t]; /* not widely supported */
-external removeEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "removeEventListener" [@@bs.send.pipe: t];
-let removeEventListenerUseCapture : string => (DomRe.event => unit) => t => unit = fun type_ listener self => removeEventListenerUseCapture type_ listener (Js.Boolean.to_js_boolean true) self;
-external dispatchEvent : DomRe.event => Js.boolean = "" [@@bs.send.pipe: t];
+  external asEventTarget : t_eventtarget => DomRe.eventTarget = "%identity";
+  
+  external addEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
+  external addEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
+  external addEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget];
+  let addEventListenerUseCapture : string => (DomRe.event => unit) => t_eventtarget => unit = fun type_ listener self => addEventListenerUseCapture type_ listener (Js.Boolean.to_js_boolean true) self;
+  external removeEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
+  external removeEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
+  external removeEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget];
+  let removeEventListenerUseCapture : string => (DomRe.event => unit) => t_eventtarget => unit = fun type_ listener self => removeEventListenerUseCapture type_ listener (Js.Boolean.to_js_boolean true) self;
+  external dispatchEvent : DomRe.event => Js.boolean = "" [@@bs.send.pipe: t_eventtarget];
+};
+
+include Impl { type t = DomRe.eventTarget };

--- a/src/dom/htmlDocumentRe.re
+++ b/src/dom/htmlDocumentRe.re
@@ -1,84 +1,87 @@
-type t = DomRe.htmlDocument;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_htmlDocument = Type.t;
 
-external asNode : t => DomRe.node = "%identity";
-external asEventTarget : t => DomRe.eventTarget = "%identity";
-external asDocument : t => DomRe.document = "%identity";
+  type designMode =
+  | On
+  | Off
+  | Unknown;
+  let encodeDesignMode = fun /* internal */
+  | On      => "on"
+  | Off     => "off"
+  | Unknown => "";
+  let decodeDesignMode = fun /* internal */
+  | "on"  => On
+  | "off" => Off
+  | _     => Unknown;
 
-type designMode =
-| On
-| Off
-| Unknown;
-let encodeDesignMode = fun /* internal */
-| On      => "on"
-| Off     => "off"
-| Unknown => "";
-let decodeDesignMode = fun /* internal */
-| "on"  => On
-| "off" => Off
-| _     => Unknown;
+  type readyState =
+  | Loading
+  | Interactive
+  | Complete
+  | Unknown;
+  let decodeReadyState = fun /* internal */
+  | "loading"     => Loading
+  | "interactive" => Interactive
+  | "complete"    => Complete
+  | _             => Unknown;
 
-type readyState =
-| Loading
-| Interactive
-| Complete
-| Unknown;
-let decodeReadyState = fun /* internal */
-| "loading"     => Loading
-| "interactive" => Interactive
-| "complete"    => Complete
-| _             => Unknown;
+  external activeElement : t_htmlDocument => Js.null DomRe.element = "" [@@bs.get];
+  let activeElement : t_htmlDocument => option DomRe.element = fun self => Js.Null.to_opt (activeElement self);
+  external body : t_htmlDocument => Js.null DomRe.element = "" [@@bs.get]; /* returns Js.null HTMLBodyElement */
+  let body : t_htmlDocument => option DomRe.element = fun self => Js.Null.to_opt (body self);
+  external setBody : t_htmlDocument => DomRe.element => unit = "body" [@@bs.set]; /* accepth HTMLBodyElement */
+  external cookie : t_htmlDocument => string = "" [@@bs.get];
+  external setCookie : t_htmlDocument => string => unit = "cookie" [@@bs.set];
+  external defaultView : t_htmlDocument => Js.null DomRe.window = "" [@@bs.get];
+  let defautView : t_htmlDocument => option DomRe.window = fun self => Js.Null.to_opt (defaultView self);
+  external designMode : t_htmlDocument => string /* designMode enum */ = "" [@@bs.get];
+  let designMode : t_htmlDocument => designMode = fun self => decodeDesignMode (designMode self);
+  external setDesignMode : t_htmlDocument => string /* designMode enum */ => unit = "designMode" [@@bs.set];
+  let setDesignMode : t_htmlDocument => designMode => unit = fun self value => setDesignMode self (encodeDesignMode value);
+  external dir : t_htmlDocument => string /* dir enum */ = "" [@@bs.get];
+  let dir : t_htmlDocument => DomRe.dir = fun self => DomRe.decodeDir (dir self);
+  external setDir : t_htmlDocument => string /* dir enum */ => unit = "dir" [@@bs.set];
+  let setDir : t_htmlDocument => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
+  external domain : t_htmlDocument => Js.null string = "" [@@bs.get];
+  let domain : t_htmlDocument => option string = fun self => Js.Null.to_opt (domain self);
+  external setDomain : t_htmlDocument => string => unit = "domain" [@@bs.set];
+  external embeds : t_htmlDocument => DomRe.nodeList = "" [@@bs.get];
+  external forms : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external head : t_htmlDocument => DomRe.element = "" [@@bs.get]; /* returns HTMLHeadElement */
+  external images : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external lastModified : t_htmlDocument => string = "" [@@bs.get];
+  external links : t_htmlDocument => DomRe.nodeList = "" [@@bs.get];
+  external location : t_htmlDocument => DomRe.location = "" [@@bs.get];
+  external setLocation : t_htmlDocument => string => unit = "location" [@@bs.set];
+  external plugins : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external readyState : t_htmlDocument => string /* enum */ = "" [@@bs.get];
+  let readyState : t_htmlDocument => readyState = fun self => decodeReadyState (readyState self);
+  external referrer : t_htmlDocument => string = "" [@@bs.get];
+  external scripts : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external title : t_htmlDocument => string = "" [@@bs.get];
+  external setTitle : t_htmlDocument => string => unit = "title" [@@bs.set];
+  external url : t_htmlDocument => string = "URL" [@@bs.get];
 
-external activeElement : t => Js.null DomRe.element = "" [@@bs.get];
-let activeElement : t => option DomRe.element = fun self => Js.Null.to_opt (activeElement self);
-external body : t => Js.null DomRe.element = "" [@@bs.get]; /* returns Js.null HTMLBodyElement */
-let body : t => option DomRe.element = fun self => Js.Null.to_opt (body self);
-external setBody : t => DomRe.element => unit = "body" [@@bs.set]; /* accepth HTMLBodyElement */
-external cookie : t => string = "" [@@bs.get];
-external setCookie : t => string => unit = "cookie" [@@bs.set];
-external defaultView : t => Js.null DomRe.window = "" [@@bs.get];
-let defautView : t => option DomRe.window = fun self => Js.Null.to_opt (defaultView self);
-external designMode : t => string /* designMode enum */ = "" [@@bs.get];
-let designMode : t => designMode = fun self => decodeDesignMode (designMode self);
-external setDesignMode : t => string /* designMode enum */ => unit = "designMode" [@@bs.set];
-let setDesignMode : t => designMode => unit = fun self value => setDesignMode self (encodeDesignMode value);
-external dir : t => string /* dir enum */ = "" [@@bs.get];
-let dir : t => DomRe.dir = fun self => DomRe.decodeDir (dir self);
-external setDir : t => string /* dir enum */ => unit = "dir" [@@bs.set];
-let setDir : t => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
-external domain : t => Js.null string = "" [@@bs.get];
-let domain : t => option string = fun self => Js.Null.to_opt (domain self);
-external setDomain : t => string => unit = "domain" [@@bs.set];
-external embeds : t => DomRe.nodeList = "" [@@bs.get];
-external forms : t => DomRe.htmlCollection = "" [@@bs.get];
-external head : t => DomRe.element = "" [@@bs.get]; /* returns HTMLHeadElement */
-external images : t => DomRe.htmlCollection = "" [@@bs.get];
-external lastModified : t => string = "" [@@bs.get];
-external links : t => DomRe.nodeList = "" [@@bs.get];
-external location : t => DomRe.location = "" [@@bs.get];
-external setLocation : t => string => unit = "location" [@@bs.set];
-external plugins : t => DomRe.htmlCollection = "" [@@bs.get];
-external readyState : t => string /* enum */ = "" [@@bs.get];
-let readyState : t => readyState = fun self => decodeReadyState (readyState self);
-external referrer : t => string = "" [@@bs.get];
-external scripts : t => DomRe.htmlCollection = "" [@@bs.get];
-external title : t => string = "" [@@bs.get];
-external setTitle : t => string => unit = "title" [@@bs.set];
-external url : t => string = "URL" [@@bs.get];
+  external close : unit = "" [@@bs.send.pipe: t_htmlDocument];
+  external execCommand : string => Js.boolean => Js.null string => Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
+  let execCommand : string => bool => option string => t_htmlDocument => bool = fun command show value self => Js.to_bool (execCommand command (Js.Boolean.to_js_boolean show) (Js.Null.from_opt value) self);
+  external getElementsByName : string => DomRe.nodeList = "" [@@bs.send.pipe: t_htmlDocument];
+  external getSelection : DomRe.selection = "" [@@bs.send.pipe: t_htmlDocument];
+  external hasFocus : Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
+  let hasFocus : t_htmlDocument => bool = fun self => Js.to_bool (hasFocus self);
+  external open_ : unit = "open" [@@bs.send.pipe: t_htmlDocument];
+  external queryCommandEnabled : string => Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
+  let queryCommandEnabled : string => t_htmlDocument => bool = fun command self => Js.to_bool (queryCommandEnabled command self);
+  external queryCommandIndeterm : string => Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
+  let queryCommandIndeterm : string => t_htmlDocument => bool = fun command self => Js.to_bool (queryCommandIndeterm command self);
+  external queryCommandSupported : string => Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
+  let queryCommandSupported : string => t_htmlDocument => bool = fun command self => Js.to_bool (queryCommandSupported command self);
+  external queryCommandValue : string => string = "" [@@bs.send.pipe: t_htmlDocument];
+  external write : string => unit = "" [@@bs.send.pipe: t_htmlDocument];
+  external writeln : string => unit = "" [@@bs.send.pipe: t_htmlDocument];
+};
 
-external close : unit = "" [@@bs.send.pipe: t];
-external execCommand : string => Js.boolean => Js.null string => Js.boolean = "" [@@bs.send.pipe: t];
-let execCommand : string => bool => option string => t => bool = fun command show value self => Js.to_bool (execCommand command (Js.Boolean.to_js_boolean show) (Js.Null.from_opt value) self);
-external getElementsByName : string => DomRe.nodeList = "" [@@bs.send.pipe: t];
-external getSelection : DomRe.selection = "" [@@bs.send.pipe: t];
-external hasFocus : Js.boolean = "" [@@bs.send.pipe: t];
-let hasFocus : t => bool = fun self => Js.to_bool (hasFocus self);
-external open_ : unit = "open" [@@bs.send.pipe: t];
-external queryCommandEnabled : string => Js.boolean = "" [@@bs.send.pipe: t];
-let queryCommandEnabled : string => t => bool = fun command self => Js.to_bool (queryCommandEnabled command self);
-external queryCommandIndeterm : string => Js.boolean = "" [@@bs.send.pipe: t];
-let queryCommandIndeterm : string => t => bool = fun command self => Js.to_bool (queryCommandIndeterm command self);
-external queryCommandSupported : string => Js.boolean = "" [@@bs.send.pipe: t];
-let queryCommandSupported : string => t => bool = fun command self => Js.to_bool (queryCommandSupported command self);
-external queryCommandValue : string => string = "" [@@bs.send.pipe: t];
-external write : string => unit = "" [@@bs.send.pipe: t];
-external writeln : string => unit = "" [@@bs.send.pipe: t];
+include NodeRe.Impl { type t = DomRe.htmlDocument };
+include EventTargetRe.Impl { type t = DomRe.htmlDocument };
+include DocumentRe.Impl { type t = DomRe.htmlDocument };
+include Impl { type t = DomRe.htmlDocument };

--- a/src/dom/htmlElementRe.re
+++ b/src/dom/htmlElementRe.re
@@ -1,100 +1,112 @@
-type t = DomRe.htmlElement;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_htmlElement = Type.t;
 
-external asNode : t => DomRe.node = "%identity";
-external asEventTarget : t => DomRe.eventTarget = "%identity";
-external asElement : t => DomRe.element = "%identity";
+  let ofElement element: option t_htmlElement =>
+    (ElementRe.tagName element) == "html" ? Some (DomInternalRe.cast element) : None;
 
-let ofElement element: option t =>
-  (ElementRe.tagName element) == "html" ? Some (DomRe.cast element) : None;
+  type contentEditable =
+  | True
+  | False
+  | Inherit
+  | Unknown;
+  let encodeContentEditable = fun /* internal */
+  | True    => "true"
+  | False   => "false"
+  | Inherit => "inherit"
+  | Unknown => "";
+  let decodeContentEditable = fun /* internal */
+  | "true"    => True
+  | "false"   => False
+  | "inherit" => Inherit
+  | _         => Unknown;
 
-type contentEditable =
-| True
-| False
-| Inherit
-| Unknown;
-let encodeContentEditable = fun /* internal */
-| True    => "true"
-| False   => "false"
-| Inherit => "inherit"
-| Unknown => "";
-let decodeContentEditable = fun /* internal */
-| "true"    => True
-| "false"   => False
-| "inherit" => Inherit
-| _         => Unknown;
+  external accessKey : t_htmlElement => string = "" [@@bs.get];
+  external setAccessKey : t_htmlElement => string => unit = "accessKey" [@@bs.set];
+  external accessKeyLabel : t_htmlElement => string = "" [@@bs.get];
+  external contentEditable : t_htmlElement => string /* enum */ = "" [@@bs.get];
+  let contentEditable : t_htmlElement => contentEditable = fun self => decodeContentEditable (contentEditable self);
+  external setContentEditable : t_htmlElement => string /* enum */ => unit = "contentEditable" [@@bs.set];
+  let setContentEditable : t_htmlElement => contentEditable => unit = fun  self value => setContentEditable self (encodeContentEditable value);
+  external isContentEditable : t_htmlElement => Js.boolean = "" [@@bs.get];
+  let isContentEditable : t_htmlElement => bool = fun self => Js.to_bool (isContentEditable self);
+  external contextMenu : t_htmlElement => DomRe.htmlElement = "" [@@bs.get]; /* returns HTMLMenuElement */
+  external setContextMenu : t_htmlElement => DomRe.htmlElement => unit = "contextMenu" [@@bs.set]; /* accepts and returns HTMLMenuElement */
+  external dataset : t_htmlElement => DomRe.domStringMap = "" [@@bs.get];
+  external dir : t_htmlElement => string /* enum */ = "" [@@bs.get];
+  let dir : t_htmlElement => DomRe.dir = fun self => DomRe.decodeDir (dir self);
+  external setDir : t_htmlElement => string /* enum */ => unit = "dir" [@@bs.set];
+  let setDir : t_htmlElement => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
+  external draggable : t_htmlElement => Js.boolean = "" [@@bs.get];
+  let draggable : t_htmlElement => bool = fun self => Js.to_bool (draggable self);
+  external setDraggable : t_htmlElement => Js.boolean => unit = "draggable" [@@bs.set];
+  let setDraggable : t_htmlElement => bool => unit = fun self value => setDraggable self (Js.Boolean.to_js_boolean value);
+  external dropzone : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get];
+  external hidden : t_htmlElement => Js.boolean = "" [@@bs.get];
+  let hidden : t_htmlElement => bool = fun self => Js.to_bool (hidden self);
+  external setHidden : t_htmlElement => Js.boolean => unit = "hidden" [@@bs.set];
+  let setHidden : t_htmlElement => bool => unit = fun self value => setHidden self (Js.Boolean.to_js_boolean value);
+  external itemScope : t_htmlElement => Js.boolean = "" [@@bs.get]; /* experimental */
+  let itemScope : t_htmlElement => bool = fun self => Js.to_bool (itemScope self);
+  external setItemScope : t_htmlElement => Js.boolean => unit = "itemScope" [@@bs.set]; /* experimental */
+  let setItemScope : t_htmlElement => bool => unit = fun self value => setItemScope self (Js.Boolean.to_js_boolean value);
+  external itemType : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemId : t_htmlElement => string = "" [@@bs.get]; /* experimental */
+  external setItemId : t_htmlElement => string => unit = "itemId" [@@bs.set]; /* experimental */
+  external itemRef : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemProp : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemValue : t_htmlElement => Js.t {..} = "" [@@bs.get]; /* experimental */
+  external setItemValue : t_htmlElement => Js.t {..} => unit = "itemValue" [@@bs.set]; /* experimental */
+  external lang : t_htmlElement => string = "" [@@bs.get];
+  external setLang : t_htmlElement => string => unit = "lang" [@@bs.set];
+  external offsetHeight : t_htmlElement => int = "" [@@bs.get]; /* experimental */
+  external offsetLeft : t_htmlElement => int = "" [@@bs.get]; /* experimental */
+  external offsetParent : t_htmlElement => int = "" [@@bs.get]; /* experimental */
+  external offsetTop : t_htmlElement => int = "" [@@bs.get]; /* experimental, but widely supported */
+  external offsetWidth : t_htmlElement => int = "" [@@bs.get]; /* experimental */
+  /*external properties : r => HTMLPropertiesCollection.t = "properties" [@@bs.get]; /* experimental */*/
+  external spellcheck : t_htmlElement => Js.boolean = "" [@@bs.get];
+  let spellcheck : t_htmlElement => bool = fun self => Js.to_bool (spellcheck self);
+  external setSpellcheck : t_htmlElement => Js.boolean => unit = "spellcheck" [@@bs.set];
+  let setSpellcheck : t_htmlElement => bool => unit = fun self value => setSpellcheck self (Js.Boolean.to_js_boolean value);
+  external style : t_htmlElement => DomRe.cssStyleDeclaration = "" [@@bs.get];
+  external setStyle : t_htmlElement => DomRe.cssStyleDeclaration => unit = "style" [@@bs.set];
+  external tabIndex : t_htmlElement => int = "" [@@bs.get];
+  external setTabIndex : t_htmlElement => int => unit = "tabIndex" [@@bs.set];
+  external title : t_htmlElement => string = "" [@@bs.get];
+  external setTitle : t_htmlElement => string => unit = "title" [@@bs.set];
+  external translate : t_htmlElement => Js.boolean = "" [@@bs.get]; /* experimental */
+  let translate : t_htmlElement => bool = fun self => Js.to_bool (translate self);
+  external setTranslate : t_htmlElement => Js.boolean => unit = "translate" [@@bs.set]; /* experimental */
+  let setTranslate : t_htmlElement => bool => unit = fun self value => setTranslate self (Js.Boolean.to_js_boolean value);
 
-external accessKey : t => string = "" [@@bs.get];
-external setAccessKey : t => string => unit = "accessKey" [@@bs.set];
-external accessKeyLabel : t => string = "" [@@bs.get];
-external contentEditable : t => string /* enum */ = "" [@@bs.get];
-let contentEditable : t => contentEditable = fun self => decodeContentEditable (contentEditable self);
-external setContentEditable : t => string /* enum */ => unit = "contentEditable" [@@bs.set];
-let setContentEditable : t => contentEditable => unit = fun  self value => setContentEditable self (encodeContentEditable value);
-external isContentEditable : t => Js.boolean = "" [@@bs.get];
-let isContentEditable : t => bool = fun self => Js.to_bool (isContentEditable self);
-external contextMenu : t => t = "" [@@bs.get]; /* returns HTMLMenuElement */
-external setContextMenu : t => t => unit = "contextMenu" [@@bs.set]; /* accepts and returns HTMLMenuElement */
-external dataset : t => DomRe.domStringMap = "" [@@bs.get];
-external dir : t => string /* enum */ = "" [@@bs.get];
-let dir : t => DomRe.dir = fun self => DomRe.decodeDir (dir self);
-external setDir : t => string /* enum */ => unit = "dir" [@@bs.set];
-let setDir : t => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
-external draggable : t => Js.boolean = "" [@@bs.get];
-let draggable : t => bool = fun self => Js.to_bool (draggable self);
-external setDraggable : t => Js.boolean => unit = "draggable" [@@bs.set];
-let setDraggable : t => bool => unit = fun self value => setDraggable self (Js.Boolean.to_js_boolean value);
-external dropzone : t => DomRe.domSettableTokenList = "" [@@bs.get];
-external hidden : t => Js.boolean = "" [@@bs.get];
-let hidden : t => bool = fun self => Js.to_bool (hidden self);
-external setHidden : t => Js.boolean => unit = "hidden" [@@bs.set];
-let setHidden : t => bool => unit = fun self value => setHidden self (Js.Boolean.to_js_boolean value);
-external itemScope : t => Js.boolean = "" [@@bs.get]; /* experimental */
-let itemScope : t => bool = fun self => Js.to_bool (itemScope self);
-external setItemScope : t => Js.boolean => unit = "itemScope" [@@bs.set]; /* experimental */
-let setItemScope : t => bool => unit = fun self value => setItemScope self (Js.Boolean.to_js_boolean value);
-external itemType : t => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
-external itemId : t => string = "" [@@bs.get]; /* experimental */
-external setItemId : t => string => unit = "itemId" [@@bs.set]; /* experimental */
-external itemRef : t => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
-external itemProp : t => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
-external itemValue : t => Js.t {..} = "" [@@bs.get]; /* experimental */
-external setItemValue : t => Js.t {..} => unit = "itemValue" [@@bs.set]; /* experimental */
-external lang : t => string = "" [@@bs.get];
-external setLang : t => string => unit = "lang" [@@bs.set];
-external offsetHeight : t => int = "" [@@bs.get]; /* experimental */
-external offsetLeft : t => int = "" [@@bs.get]; /* experimental */
-external offsetParent : t => int = "" [@@bs.get]; /* experimental */
-external offsetTop : t => int = "" [@@bs.get]; /* experimental, but widely supported */
-external offsetWidth : t => int = "" [@@bs.get]; /* experimental */
-/*external properties : r => HTMLPropertiesCollection.t = "properties" [@@bs.get]; /* experimental */*/
-external spellcheck : t => Js.boolean = "" [@@bs.get];
-let spellcheck : t => bool = fun self => Js.to_bool (spellcheck self);
-external setSpellcheck : t => Js.boolean => unit = "spellcheck" [@@bs.set];
-let setSpellcheck : t => bool => unit = fun self value => setSpellcheck self (Js.Boolean.to_js_boolean value);
-external style : t => DomRe.cssStyleDeclaration = "" [@@bs.get];
-external setStyle : t => DomRe.cssStyleDeclaration => unit = "style" [@@bs.set];
-external tabIndex : t => int = "" [@@bs.get];
-external setTabIndex : t => int => unit = "tabIndex" [@@bs.set];
-external title : t => string = "" [@@bs.get];
-external setTitle : t => string => unit = "title" [@@bs.set];
-external translate : t => Js.boolean = "" [@@bs.get]; /* experimental */
-let translate : t => bool = fun self => Js.to_bool (translate self);
-external setTranslate : t => Js.boolean => unit = "translate" [@@bs.set]; /* experimental */
-let setTranslate : t => bool => unit = fun self value => setTranslate self (Js.Boolean.to_js_boolean value);
-
-external blur : unit = "" [@@bs.send.pipe: t];
-external click : unit = "" [@@bs.send.pipe: t];
-external focus : unit = "" [@@bs.send.pipe: t];
-external forceSpellCheck : unit = "" [@@bs.send.pipe: t]; /* experimental */
+  external blur : unit = "" [@@bs.send.pipe: t_htmlElement];
+  external click : unit = "" [@@bs.send.pipe: t_htmlElement];
+  external focus : unit = "" [@@bs.send.pipe: t_htmlElement];
+  external forceSpellCheck : unit = "" [@@bs.send.pipe: t_htmlElement]; /* experimental */
 
 
-/* TODO: element-spcific, should be pulled out */
-external value : t => string = "" [@@bs.get]; /* HTMLInputElement */
-external checked : t => Js.boolean = "" [@@bs.get]; /* HTMLInputElement */
-let checked : t => bool = fun value => Js.to_bool (checked value);
-external type_ : t => string = "" [@@bs.get]; /* HTMLStyleElement */
-external setType : t => string => unit = "type" [@@bs.set]; /* HTMLStyleElement */
-external rel : t => string = "" [@@bs.get]; /* HTMLLinkElement */
-external setRel : t => string => unit = "rel" [@@bs.set]; /* HTMLLinkElement */
-external href : t => string = "" [@@bs.get]; /* HTMLLinkElement, HTMLAnchorElement */
-external setHref : t => string => unit = "href" [@@bs.set]; /* HTMLLinkElement, HTMLAnchorElement */
+  /* TODO: element-spcific, should be pulled out */
+  external value : t_htmlElement => string = "" [@@bs.get]; /* HTMLInputElement */
+  external checked : t_htmlElement => Js.boolean = "" [@@bs.get]; /* HTMLInputElement */
+  let checked : t_htmlElement => bool = fun value => Js.to_bool (checked value);
+  external type_ : t_htmlElement => string = "" [@@bs.get]; /* HTMLStyleElement */
+  external setType : t_htmlElement => string => unit = "type" [@@bs.set]; /* HTMLStyleElement */
+  external rel : t_htmlElement => string = "" [@@bs.get]; /* HTMLLinkElement */
+  external setRel : t_htmlElement => string => unit = "rel" [@@bs.set]; /* HTMLLinkElement */
+  external href : t_htmlElement => string = "" [@@bs.get]; /* HTMLLinkElement, HTMLAnchorElement */
+  external setHref : t_htmlElement => string => unit = "href" [@@bs.set]; /* HTMLLinkElement, HTMLAnchorElement */
+};
+
+/* TODO
+module Tree (Type: DomInternalRe.Type) => {
+  include ElementRe.Tree { type t = Type };
+  include Impl { type t = Type };
+};
+
+include Tree { type t = DomRe.htmlElement };
+*/
+
+include NodeRe.Impl { type t = DomRe.htmlElement };
+include EventTargetRe.Impl { type t = DomRe.htmlElement };
+include ElementRe.Impl { type t = DomRe.htmlElement };
+include Impl { type t = DomRe.htmlElement };

--- a/src/dom/nodeRe.re
+++ b/src/dom/nodeRe.re
@@ -1,87 +1,93 @@
-type t = DomRe.node;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_node = Type.t;
 
-type nodeType =
-| Element
-| Attribute /* deprecated */
-| Text
-| CDATASection /* deprecated */
-| EntityReference /* deprecated */
-| Entity /* deprecated */
-| ProcessingInstruction
-| Comment
-| Document
-| DocumentType
-| DocumentFragment
-| Notation /* deprecated */
-| Unknown;
-let decodeNodeType = fun /* internal */
-|  1 => Element
-|  2 => Attribute
-|  3 => Text
-|  4 => CDATASection
-|  5 => EntityReference
-|  6 => Entity
-|  7 => ProcessingInstruction
-|  8 => Comment
-|  9 => Document
-| 10 => DocumentType
-| 11 => DocumentFragment
-| 12 => Notation
-|  _ => Unknown;
+  type nodeType =
+  | Element
+  | Attribute /* deprecated */
+  | Text
+  | CDATASection /* deprecated */
+  | EntityReference /* deprecated */
+  | Entity /* deprecated */
+  | ProcessingInstruction
+  | Comment
+  | Document
+  | DocumentType
+  | DocumentFragment
+  | Notation /* deprecated */
+  | Unknown;
+  let decodeNodeType = fun /* internal */
+  |  1 => Element
+  |  2 => Attribute
+  |  3 => Text
+  |  4 => CDATASection
+  |  5 => EntityReference
+  |  6 => Entity
+  |  7 => ProcessingInstruction
+  |  8 => Comment
+  |  9 => Document
+  | 10 => DocumentType
+  | 11 => DocumentFragment
+  | 12 => Notation
+  |  _ => Unknown;
 
-/* baseURI */
-external childNodes : t => DomRe.nodeList  = "" [@@bs.get];
-external firstChild : t => Js.null t = "" [@@bs.get];
-let firstChild : t => option t = fun self => Js.Null.to_opt (firstChild self);
-external innerText : t => string = "" [@@bs.get];
-external setInnerText : t => string => unit = "innerText" [@@bs.set];
-external lastChild : t => Js.null t = "" [@@bs.get];
-let lastChild : t => option t = fun self => Js.Null.to_opt (lastChild self);
-external nextSibling : t => Js.null t = "" [@@bs.get];
-let nextSibling : t => option t = fun self => Js.Null.to_opt (nextSibling self);
-external nodeName : t => string = "" [@@bs.get];
-/* nodePrincipal */
-external nodeType : t => int /* nodeType enum */ = "" [@@bs.get];
-let nodeType : t => nodeType = fun self => decodeNodeType (nodeType self);
-external nodeValue : t => Js.null string = "" [@@bs.get];
-let nodeValue : t => option string = fun self => Js.Null.to_opt (nodeValue self);
-external setNodeValue : t => Js.null string => unit = "nodeValue" [@@bs.set];
-let setNodeValue : t => option string => unit = fun self value => setNodeValue self (Js.Null.from_opt value);
-/* outerText */
-external ownerDocument : t => DomRe.document = "" [@@bs.get];
-external parentElement : t => Js.null DomRe.element = "" [@@bs.get];
-let parentElement : t => option DomRe.element = fun self => Js.Null.to_opt (parentElement self);
-external parentNode : t => Js.null t = "" [@@bs.get];
-let parentNode : t => option t = fun self => Js.Null.to_opt (parentNode self);
-external previousSibling : t => Js.null t = "" [@@bs.get];
-let previousSibling : t => option t = fun self => Js.Null.to_opt (previousSibling self);
-external rootNode : t => t = "" [@@bs.get];
-external textContent : t => string = "" [@@bs.get];
-external setTextContent : t => string => unit = "textContent" [@@bs.set];
+  external asNode : t_node => DomRe.node = "%identity";
 
-external appendChild : t => unit = "" [@@bs.send.pipe: t];
-external cloneNode : t = "" [@@bs.send.pipe: t];
-external cloneNodeDeep : Js.boolean => t = "cloneNode" [@@bs.send.pipe: t];
-let cloneNodeDeep : t => t = fun self => cloneNodeDeep (Js.Boolean.to_js_boolean true) self;
-external compareDocumentPosition : t => int = "" [@@bs.send.pipe: t]; /* returns a bitmask which could also be represeneted as an enum, see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition */
-external contains : t => Js.boolean = "" [@@bs.send.pipe: t];
-let contains : t => t => bool = fun node self => Js.to_bool (contains node self);
-external getRootNode : t = "" [@@bs.send.pipe: t];
-external getRootNodeComposed : Js.boolean => t = "getRootNode" [@@bs.send.pipe: t];
-let getRootNodeComposed : t => t = fun self => getRootNodeComposed (Js.Boolean.to_js_boolean true) self;
-external hasChildNodes : Js.boolean = "" [@@bs.send.pipe: t];
-let hasChildNodes : t => bool = fun self => Js.to_bool (hasChildNodes self);
-external insertBefore : t => Js.null t => t = "" [@@bs.send.pipe: t];
-let insertBefore : t => option t => t => t = fun node reference self => insertBefore node (Js.Null.from_opt reference) self;
-external isDefaultNamespace : string => Js.boolean = "" [@@bs.send.pipe: t];
-let isDefaultNamespace : string => t => bool = fun ns self => Js.to_bool (isDefaultNamespace ns self);
-external isEqualNode : t => Js.boolean = "" [@@bs.send.pipe: t];
-let isEqualNode: t => t => bool = fun node self => Js.to_bool (isEqualNode node self);
-external isSameNode : t => Js.boolean = "" [@@bs.send.pipe: t];
-let isSameNode: t => t => bool = fun node self => Js.to_bool (isSameNode node self);
-external lookupNamespaceURI : Js.null string => Js.null string = "" [@@bs.send.pipe: t];
-let lookupNamespaceURI: option string => t => option string = fun prefix self => Js.Null.to_opt (lookupNamespaceURI (Js.Null.from_opt prefix) self);
-external lookupPrefix : string = "lookupPrefix" [@@bs.send.pipe: t];
-external normalize : unit = "" [@@bs.send.pipe: t];
-external removeChild : t => t = "" [@@bs.send.pipe: t];
-/* replacChild */
+  /* baseURI */
+  external childNodes : t_node => DomRe.nodeList  = "" [@@bs.get];
+  external firstChild : t_node => Js.null DomRe.node = "" [@@bs.get];
+  let firstChild : t_node => option DomRe.node = fun self => Js.Null.to_opt (firstChild self);
+  external innerText : t_node => string = "" [@@bs.get];
+  external setInnerText : t_node => string => unit = "innerText" [@@bs.set];
+  external lastChild : t_node => Js.null DomRe.node = "" [@@bs.get];
+  let lastChild : t_node => option DomRe.node = fun self => Js.Null.to_opt (lastChild self);
+  external nextSibling : t_node => Js.null DomRe.node = "" [@@bs.get];
+  let nextSibling : t_node => option DomRe.node = fun self => Js.Null.to_opt (nextSibling self);
+  external nodeName : t_node => string = "" [@@bs.get];
+  /* nodePrincipal */
+  external nodeType : t_node => int /* nodeType enum */ = "" [@@bs.get];
+  let nodeType : t_node => nodeType = fun self => decodeNodeType (nodeType self);
+  external nodeValue : t_node => Js.null string = "" [@@bs.get];
+  let nodeValue : t_node => option string = fun self => Js.Null.to_opt (nodeValue self);
+  external setNodeValue : t_node => Js.null string => unit = "nodeValue" [@@bs.set];
+  let setNodeValue : t_node => option string => unit = fun self value => setNodeValue self (Js.Null.from_opt value);
+  /* outerText */
+  external ownerDocument : t_node => DomRe.document = "" [@@bs.get];
+  external parentElement : t_node => Js.null DomRe.element = "" [@@bs.get];
+  let parentElement : t_node => option DomRe.element = fun self => Js.Null.to_opt (parentElement self);
+  external parentNode : t_node => Js.null DomRe.node = "" [@@bs.get];
+  let parentNode : t_node => option DomRe.node = fun self => Js.Null.to_opt (parentNode self);
+  external previousSibling : t_node => Js.null DomRe.node = "" [@@bs.get];
+  let previousSibling : t_node => option DomRe.node = fun self => Js.Null.to_opt (previousSibling self);
+  external rootNode : t_node => DomRe.node = "" [@@bs.get];
+  external textContent : t_node => string = "" [@@bs.get];
+  external setTextContent : t_node => string => unit = "textContent" [@@bs.set];
+
+  external appendChild : DomRe.node => unit = "" [@@bs.send.pipe: t_node];
+  external cloneNode : DomRe.node = "" [@@bs.send.pipe: t_node];
+  external cloneNodeDeep : Js.boolean => DomRe.node = "cloneNode" [@@bs.send.pipe: t_node];
+  let cloneNodeDeep : t_node => DomRe.node = fun self => cloneNodeDeep (Js.Boolean.to_js_boolean true) self;
+  external compareDocumentPosition : DomRe.node => int = "" [@@bs.send.pipe: t_node]; /* returns a bitmask which could also be represeneted as an enum, see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition */
+  external contains : DomRe.node => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let contains : DomRe.node => t_node => bool = fun node self => Js.to_bool (contains node self);
+  external getRootNode : DomRe.node = "" [@@bs.send.pipe: t_node];
+  external getRootNodeComposed : Js.boolean => DomRe.node = "getRootNode" [@@bs.send.pipe: t_node];
+  let getRootNodeComposed : t_node => DomRe.node = fun self => getRootNodeComposed (Js.Boolean.to_js_boolean true) self;
+  external hasChildNodes : Js.boolean = "" [@@bs.send.pipe: t_node];
+  let hasChildNodes : t_node => bool = fun self => Js.to_bool (hasChildNodes self);
+  external insertBefore : DomRe.node => Js.null DomRe.node => DomRe.node = "" [@@bs.send.pipe: t_node];
+  let insertBefore : DomRe.node => option DomRe.node => t_node => DomRe.node = fun node reference self => insertBefore node (Js.Null.from_opt reference) self;
+  external isDefaultNamespace : string => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let isDefaultNamespace : string => t_node => bool = fun ns self => Js.to_bool (isDefaultNamespace ns self);
+  external isEqualNode : DomRe.node => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let isEqualNode: DomRe.node => t_node => bool = fun node self => Js.to_bool (isEqualNode node self);
+  external isSameNode : DomRe.node => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let isSameNode: DomRe.node => t_node => bool = fun node self => Js.to_bool (isSameNode node self);
+  external lookupNamespaceURI : Js.null string => Js.null string = "" [@@bs.send.pipe: t_node];
+  let lookupNamespaceURI: option string => t_node => option string = fun prefix self => Js.Null.to_opt (lookupNamespaceURI (Js.Null.from_opt prefix) self);
+  external lookupPrefix : string = "lookupPrefix" [@@bs.send.pipe: t_node];
+  external normalize : unit = "" [@@bs.send.pipe: t_node];
+  external removeChild : DomRe.node => DomRe.node = "" [@@bs.send.pipe: t_node];
+  /* replacChild */
+};
+
+include Impl { type t = DomRe.node };

--- a/src/dom/windowRe.re
+++ b/src/dom/windowRe.re
@@ -1,28 +1,31 @@
-type t = DomRe.window;
+module Impl (Type: DomInternalRe.Type) => {
+  type t_window = Type.t;
 
-external asEventTarget : t => DomRe.eventTarget = "%identity";
+  /* This module is far from exhaustively implemented */
 
-/* This module is far from exhaustively implemented */
+  external document : t_window => DomRe.document = "" [@@bs.get];
+  external fullScreen : t_window => Js.boolean = "" [@@bs.get];
+  let fullScreen : t_window => bool = fun self => Js.to_bool (fullScreen self);
+  external history : t_window => DomRe.history = "" [@@bs.get];
+  external innerWidth : t_window => int = "" [@@bs.get];
+  external innerHeight : t_window => int = "" [@@bs.get];
+  external location : t_window => DomRe.location = "" [@@bs.get];
+  external setLocation : t_window => string => unit = "location" [@@bs.set];
+  external parent : t_window => DomRe.window = "" [@@bs.get];
+  external top : t_window => DomRe.window = "" [@@bs.get];
+  external window : t_window => t_window = "" [@@bs.get]; /* This is really pointless I think, it's just here because window is the implicit global scope, and it's needed to be able to get a reference to it */
 
-external document : t => DomRe.document = "" [@@bs.get];
-external fullScreen : t => Js.boolean = "" [@@bs.get];
-let fullScreen : t => bool = fun self => Js.to_bool (fullScreen self);
-external history : t => DomRe.history = "" [@@bs.get];
-external innerWidth : t => int = "" [@@bs.get];
-external innerHeight : t => int = "" [@@bs.get];
-external location : t => DomRe.location = "" [@@bs.get];
-external setLocation : t => string => unit = "location" [@@bs.set];
-external parent : t => t = "" [@@bs.get];
-external top : t => t = "" [@@bs.get];
-external window : t => t = "" [@@bs.get];
+  external alert : string => unit = "" [@@bs.send.pipe: t_window];
+  external confirm : string => Js.boolean = "" [@@bs.send.pipe: t_window];
+  let confirm : string => t_window => bool = fun message self => Js.to_bool (confirm message self);
+  external getComputedStyle : DomRe.element => DomRe.cssStyleDeclaration = "" [@@bs.send.pipe: t_window];
+  external getComputedStyleWithPseudoElement : DomRe.element => string => DomRe.cssStyleDeclaration = "getComputedStyle" [@@bs.send.pipe: t_window];
+  external prompt : string => string = "" [@@bs.send.pipe: t_window];
+  external promptWithDefault : string => string => string = "prompt" [@@bs.send.pipe: t_window];
+  external scroll : int => int => unit = "" [@@bs.send.pipe: t_window];
 
-external alert : string => unit = "" [@@bs.send.pipe: t];
-external confirm : string => Js.boolean = "" [@@bs.send.pipe: t];
-let confirm : string => t => bool = fun message self => Js.to_bool (confirm message self);
-external getComputedStyle : DomRe.element => DomRe.cssStyleDeclaration = "" [@@bs.send.pipe: t];
-external getComputedStyleWithPseudoElement : DomRe.element => string => DomRe.cssStyleDeclaration = "getComputedStyle" [@@bs.send.pipe: t];
-external prompt : string => string = "" [@@bs.send.pipe: t];
-external promptWithDefault : string => string => string = "prompt" [@@bs.send.pipe: t];
-external scroll : int => int => unit = "" [@@bs.send.pipe: t];
+  external setOnLoad : t_window => (unit => unit) => unit = "onload" [@@bs.set];
+};
 
-external setOnLoad : t => (unit => unit) => unit = "onload" [@@bs.set];
+include EventTargetRe.Impl { type t = DomRe.window };
+include Impl { type t = DomRe.window };

--- a/src/reasonJs.re
+++ b/src/reasonJs.re
@@ -21,6 +21,9 @@ module Object = ObjectRe;
 module Promise = PromiseRe;
 module RegExp = RegExpRe;
 
+module Dom = DomRe;
+
+/* TODO: Should be moved into Dom */
 module CssStyleDeclaration = CssStyleDeclarationRe;
 module Document = DocumentRe;
 module DomTokenList = DomTokenListRe;


### PR DESCRIPTION
It's not terribly elegant, but it works and means less casting is needed. Specifically:
* Implementations are inherited down the tree. This means e.g. `Node.innerText` now also exists as `Element.innerText` for use on `Element`s
* There is no sub-type polymorphism, so types will still need to be manually up-casted when used with methods that expect a specific type. E.g. an `Element` will need to be casted to a `Node` to be appended with `Node.appendChild`.
* Down-casting is still needed even when you know exactly what the element is, e.g. `Document.createElement "div"` will return an `Element`, not an `HTMLDivElement`. I have some ideas on how to this might be solved too though.

Another consequence is that the `type t` convention can't be used as each included module needs to contain unique names. `DomRe` has therefore been exposed as `ReasonJs.Dom` so that e.g. what was `ReasonJs.Element.t` can now be accessed as `ReasonJs.Dom.element`.

### Implementation details:

Consider this module
```reason
type t = fooType;

let foo : t => t = ...;

/* also want to include functions of some "parent" type */
```

The pattern employed wraps "inheritable" modules in a functor that by convention should be named `Impl`:
```reason
module type TypeSig = { type t };

module Impl (Type: TypeSig) => {
  type t_foo = Type.t; /* (1) */
  let foo : t_foo => fooType = ... /* (2) */
};

include Parent.Impl { type t = fooType };
include Impl { type t = fooType };
```

et voilà!

###### Notes:
1. `type t` needs to be renamed to avoid name clashes with other inherited modules, like `Parent.Impl` in this example
2.  In most cases arguments and return types other than "self" should not be `t_foo` since, when inherited, t_foo will take on the type passed to it.