### PR TITLE
Moved Dom exports from just ReasonJs to ReasonJs.Dom

### DIFF
--- a/examples/dom_example.re
+++ b/examples/dom_example.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 /* Adapted from https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Examples#Example_7:_Displaying_Event_Object_Properties */
 
@@ -8,7 +8,7 @@ let map f => fun
 | Some v => Some (f v)
 | None => None;
 
-let and_then f => fun
+let andThen f => fun
 | Some v => f v
 | None => None;
 
@@ -64,7 +64,7 @@ document
 /* After subtyping: */
 document
   |> Document.asHtmlDocument
-  |> and_then HtmlDocument.body
+  |> andThen HtmlDocument.body
   |> map (Element.appendChild el);
 
 /*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "bsb -make-world && tests/run.sh",
-    "start": "bsb -make-world -w"
+    "start": "bsb -make-world -w",
+    "build": "bsb -make-world",
+    "clean": "bsb -clean-world"
   },
   "author": "chenglou",
   "license": "MIT",

--- a/src/dom/cssStyleDeclarationRe.re
+++ b/src/dom/cssStyleDeclarationRe.re
@@ -1,4 +1,4 @@
-type t = DomRe.cssStyleDeclaration;
+type t = DomTypesRe.cssStyleDeclaration;
 type cssRule; /* TODO: Move to DomRe */
 
 external cssText : t => string = "" [@@bs.get];

--- a/src/dom/documentRe.re
+++ b/src/dom/documentRe.re
@@ -1,14 +1,14 @@
 module Impl (Type: DomInternalRe.Type) => {
   type t_document = Type.t;
 
-  external asDocument : t_document => DomRe.document = "%identity";
+  external asDocument : t_document => DomTypesRe.document = "%identity";
 
-  let asHtmlDocument : t_document => Js.null DomRe.htmlDocument = [%bs.raw {|
+  let asHtmlDocument : t_document => Js.null DomTypesRe.htmlDocument = [%bs.raw {|
     function (document) {
       return document.doctype.name === "html" ?  document : null;
     }
   |}];
-  let asHtmlDocument : t_document => option DomRe.htmlDocument = fun self => Js.Null.to_opt (asHtmlDocument self);
+  let asHtmlDocument : t_document => option DomTypesRe.htmlDocument = fun self => Js.Null.to_opt (asHtmlDocument self);
 
   let ofNode node: option (t_document) =>
     (NodeRe.nodeType node) == Document ? Some (DomInternalRe.cast node) : None;
@@ -38,62 +38,62 @@ module Impl (Type: DomInternalRe.Type) => {
   external characterSet : t_document => string = "" [@@bs.get];
   external compatMode : t_document => string /* compatMode enum */ = "" [@@bs.get]; /* experimental */
   let compatMode : t_document => compatMode = fun self => decodeCompatMode (compatMode self);
-  external docType : t_document => DomRe.documentType = "" [@@bs.get];
-  external documentElement : t_document => DomRe.element = "" [@@bs.get];
+  external docType : t_document => DomTypesRe.documentType = "" [@@bs.get];
+  external documentElement : t_document => DomTypesRe.element = "" [@@bs.get];
   external documentURI : t_document => string = "" [@@bs.get];
   external hidden : t_document => Js.boolean = "" [@@bs.get];
   let hidden : t_document => bool = fun v => Js.to_bool (hidden v);
-  external implementation : t_document => DomRe.documentImplementation = "" [@@bs.get];
+  external implementation : t_document => DomTypesRe.documentImplementation = "" [@@bs.get];
   external lastStyleSheetSet : t_document => string = "" [@@bs.get];
-  external pointerLockElement : t_document => Js.null DomRe.element = "" [@@bs.get]; /* experimental */
-  let pointerLockElement : t_document => option DomRe.element = fun self => Js.Null.to_opt (pointerLockElement self);
+  external pointerLockElement : t_document => Js.null DomTypesRe.element = "" [@@bs.get]; /* experimental */
+  let pointerLockElement : t_document => option DomTypesRe.element = fun self => Js.Null.to_opt (pointerLockElement self);
   external preferredStyleSheetSet : t_document => string = "" [@@bs.get];
-  external scrollingElement : t_document => Js.null DomRe.element = "" [@@bs.get];
-  let scrollingElement : t_document => option DomRe.element = fun self => Js.Null.to_opt (scrollingElement self);
+  external scrollingElement : t_document => Js.null DomTypesRe.element = "" [@@bs.get];
+  let scrollingElement : t_document => option DomTypesRe.element = fun self => Js.Null.to_opt (scrollingElement self);
   external selectedStyleSheetSet : t_document => string = "" [@@bs.get];
   external setSelectedStyleSheetSet : t_document => string => unit = "selectedStyleSheetSet" [@@bs.set];
-  external styleSheets : t_document => array DomRe.cssStyleSheet = "" [@@bs.get]; /* return StyleSheetList, not array */
+  external styleSheets : t_document => array DomTypesRe.cssStyleSheet = "" [@@bs.get]; /* return StyleSheetList, not array */
   external styleSheetSets : t_document => array string = "" [@@bs.get];
   external visibilityState : t_document => string /* visibilityState enum */ = "" [@@bs.get];
   let visibilityState : t_document => visibilityState = fun self => decodeVisibilityState (visibilityState self);
 
-  external adoptNode : DomRe.element_like 'a => DomRe.element_like 'a = "" [@@bs.send.pipe: t_document];
-  external createAttribute : string => DomRe.attr = "" [@@bs.send.pipe: t_document];
-  external createAttributeNS : string => string => DomRe.attr = "" [@@bs.send.pipe: t_document];
-  external createComment : string => DomRe.comment = "" [@@bs.send.pipe: t_document];
-  external createDocumentFragment : DomRe.documentFragment = "" [@@bs.send.pipe: t_document];
-  external createElement : string => DomRe.element = "" [@@bs.send.pipe: t_document];
-  external createElementWithOptions : string => Js.t {..} => DomRe.element = "createElement" [@@bs.send.pipe: t_document]; /* not widely supported */
-  external createElementNS : string => string => DomRe.element = "" [@@bs.send.pipe: t_document];
-  external createElementNSWithOptions : string => string => Js.t {..} => DomRe.element = "createEementNS" [@@bs.send.pipe: t_document]; /* not widely supported */
-  external createEvent : string /* large enum */ => DomRe.event = "" [@@bs.send.pipe: t_document]; /* discouraged (but not deprecated) in favor of Event constructors */
-  external createNodeIterator : DomRe.node_like 'a => DomRe.nodeIterator = "" [@@bs.send.pipe: t_document];
-  external createNodeIteratorWithWhatToShow : DomRe.node_like 'a => NodeFilterRe.WhatToShow.t => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
-  external createNodeIteratorWithWhatToShowFilter : DomRe.node_like 'a => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
+  external adoptNode : DomTypesRe.element_like 'a => DomTypesRe.element_like 'a = "" [@@bs.send.pipe: t_document];
+  external createAttribute : string => DomTypesRe.attr = "" [@@bs.send.pipe: t_document];
+  external createAttributeNS : string => string => DomTypesRe.attr = "" [@@bs.send.pipe: t_document];
+  external createComment : string => DomTypesRe.comment = "" [@@bs.send.pipe: t_document];
+  external createDocumentFragment : DomTypesRe.documentFragment = "" [@@bs.send.pipe: t_document];
+  external createElement : string => DomTypesRe.element = "" [@@bs.send.pipe: t_document];
+  external createElementWithOptions : string => Js.t {..} => DomTypesRe.element = "createElement" [@@bs.send.pipe: t_document]; /* not widely supported */
+  external createElementNS : string => string => DomTypesRe.element = "" [@@bs.send.pipe: t_document];
+  external createElementNSWithOptions : string => string => Js.t {..} => DomTypesRe.element = "createEementNS" [@@bs.send.pipe: t_document]; /* not widely supported */
+  external createEvent : string /* large enum */ => DomTypesRe.event = "" [@@bs.send.pipe: t_document]; /* discouraged (but not deprecated) in favor of Event constructors */
+  external createNodeIterator : DomTypesRe.node_like 'a => DomTypesRe.nodeIterator = "" [@@bs.send.pipe: t_document];
+  external createNodeIteratorWithWhatToShow : DomTypesRe.node_like 'a => NodeFilterRe.WhatToShow.t => DomTypesRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
+  external createNodeIteratorWithWhatToShowFilter : DomTypesRe.node_like 'a => NodeFilterRe.WhatToShow.t => DomTypesRe.nodeFilter => DomTypesRe.nodeIterator = "createNodeIterator" [@@bs.send.pipe: t_document];
   /* createProcessingInstruction */
-  external createRange : DomRe.range = "" [@@bs.send.pipe: t_document];
-  external createText : string => DomRe.textNode = "" [@@bs.send.pipe: t_document];
-  external createTreeWalker : DomRe.element_like 'a => DomRe.treeWalker = "" [@@bs.send.pipe: t_document];
-  external createTreeWalkerWithWhatToShow : DomRe.element_like 'a => NodeFilterRe.WhatToShow.t => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
-  external createTreeWalkerWithWhatToShowFilter : DomRe.element_like 'a => NodeFilterRe.WhatToShow.t => DomRe.nodeFilter => DomRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
-  external elementFromPoint : int => int => DomRe.element = "" [@@bs.send.pipe: t_document]; /* experimental, but widely supported */
-  external elementsFromPoint : int => int => array DomRe.element = "" [@@bs.send.pipe: t_document]; /* experimental */
+  external createRange : DomTypesRe.range = "" [@@bs.send.pipe: t_document];
+  external createText : string => DomTypesRe.textNode = "" [@@bs.send.pipe: t_document];
+  external createTreeWalker : DomTypesRe.element_like 'a => DomTypesRe.treeWalker = "" [@@bs.send.pipe: t_document];
+  external createTreeWalkerWithWhatToShow : DomTypesRe.element_like 'a => NodeFilterRe.WhatToShow.t => DomTypesRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
+  external createTreeWalkerWithWhatToShowFilter : DomTypesRe.element_like 'a => NodeFilterRe.WhatToShow.t => DomTypesRe.nodeFilter => DomTypesRe.treeWalker = "createTreeWalker" [@@bs.send.pipe: t_document];
+  external elementFromPoint : int => int => DomTypesRe.element = "" [@@bs.send.pipe: t_document]; /* experimental, but widely supported */
+  external elementsFromPoint : int => int => array DomTypesRe.element = "" [@@bs.send.pipe: t_document]; /* experimental */
   external enableStyleSheetsForSet : string => unit = "" [@@bs.send.pipe: t_document];
   external exitPointerLock : unit = "" [@@bs.send.pipe: t_document]; /* experimental */
-  external getAnimations : array DomRe.animation = "" [@@bs.send.pipe: t_document]; /* experimental */
-  external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
-  external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
-  external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_document];
-  external importNode : DomRe.element_like 'a => DomRe.element_like 'a = "" [@@bs.send.pipe: t_document];
-  external importNodeDeep : DomRe.element_like 'a => Js.boolean => DomRe.element_like 'a = "importNode" [@@bs.send.pipe: t_document];
-  let importNodeDeep : DomRe.element_like 'a => t_document => DomRe.element_like 'a = fun element self => importNodeDeep element Js.true_ self;
-  external registerElement : string => (unit => DomRe.element) = "" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
-  external registerElementWithOptions : string => Js.t {..} => (unit => DomRe.element) = "registerElement" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
-  external getElementById : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_document];
-  let getElementById : string => t_document => option DomRe.element = fun id self => Js.Null.to_opt (getElementById id self);
-  external querySelector : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_document];
-  let querySelector : string => t_document => option DomRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
-  external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t_document];
+  external getAnimations : array DomTypesRe.animation = "" [@@bs.send.pipe: t_document]; /* experimental */
+  external getElementsByClassName : string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external getElementsByTagName : string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external getElementsByTagNameNS : string => string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_document];
+  external importNode : DomTypesRe.element_like 'a => DomTypesRe.element_like 'a = "" [@@bs.send.pipe: t_document];
+  external importNodeDeep : DomTypesRe.element_like 'a => Js.boolean => DomTypesRe.element_like 'a = "importNode" [@@bs.send.pipe: t_document];
+  let importNodeDeep : DomTypesRe.element_like 'a => t_document => DomTypesRe.element_like 'a = fun element self => importNodeDeep element Js.true_ self;
+  external registerElement : string => (unit => DomTypesRe.element) = "" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
+  external registerElementWithOptions : string => Js.t {..} => (unit => DomTypesRe.element) = "registerElement" [@@bs.send.pipe: t_document]; /* experimental and deprecated in favor of customElements.define() */
+  external getElementById : string => Js.null DomTypesRe.element = "" [@@bs.send.pipe: t_document];
+  let getElementById : string => t_document => option DomTypesRe.element = fun id self => Js.Null.to_opt (getElementById id self);
+  external querySelector : string => Js.null DomTypesRe.element = "" [@@bs.send.pipe: t_document];
+  let querySelector : string => t_document => option DomTypesRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
+  external querySelectorAll : string => DomTypesRe.nodeList = "" [@@bs.send.pipe: t_document];
 
   /** XPath stuff */
   /* createExpression */
@@ -103,6 +103,6 @@ module Impl (Type: DomInternalRe.Type) => {
   /* GlobalEventHandlers interface */
 };
 
-include NodeRe.Impl { type t = DomRe.document };
-include EventTargetRe.Impl { type t = DomRe.document };
-include Impl { type t = DomRe.document };
+include NodeRe.Impl { type t = DomTypesRe.document };
+include EventTargetRe.Impl { type t = DomTypesRe.document };
+include Impl { type t = DomTypesRe.document };

--- a/src/dom/domRe.re
+++ b/src/dom/domRe.re
@@ -1,61 +1,25 @@
-type animation;
-type attr;
-type comment;
-type cssStyleDeclaration;
-type cssStyleSheet;
-type documentFragment;
-type documentImplementation;
-type documentType;
-type domRect;
-type domSettableTokenList;
-type domStringMap;
-type domTokenList;
 
-type node_like 'a;
-type node = node_like unit;
-type element_tag 'a;
-type element_like 'a = node_like (element_tag 'a);
-type element = element_like unit;
-type htmlElement_tag 'a;
-type htmlElement_like 'a = element_like (htmlElement_tag 'a);
-type htmlElement = htmlElement_like unit;
-type document_tag 'a;
-type document_like 'a = node_like (document_tag 'a);
-type document = document_like unit;
-type htmlDocument_tag;
-type htmlDocument = document_like htmlDocument_tag;
+module CssStyleDeclaration = CssStyleDeclarationRe;
+module Document = DocumentRe;
+module DomTokenList = DomTokenListRe;
+module Element = ElementRe;
+module Event = EventRe;
+module EventTarget = EventTargetRe;
+module History = HistoryRe;
+module HtmlCollection = HtmlCollectionRe;
+module HtmlDocument = HtmlDocumentRe;
+module HtmlElement = HtmlElementRe;
+module Location = LocationRe;
+module Node = NodeRe;
+module NodeFilter = NodeFilterRe;
+module NodeList = NodeListRe;
+module Range = RangeRe;
+module Selection = SelectionRe;
+module Window = WindowRe;
 
-type shadowRoot_tag;
-type shadowRoot = node_like shadowRoot_tag;
+include DomTypesRe;
 
-type event;
-type eventTarget;
-type history;
-type htmlCollection;
-type location;
-type nodeFilter = {
-  acceptNode: element => int /* return type should be NodeFilter.action, but that would create a cycle */
-};
-type nodeIterator;
-type nodeList;
-type range;
-type selection;
-type textNode;
-type treeWalker;
-type window;
-
-/* special */
-type eventPointerId;
-
-type dir =
-| Ltr
-| Rtl
-| Unknown;
-let encodeDir = fun /* internal */
-| Ltr     => "ltr"
-| Rtl     => "rtl"
-| Unknown => "";
-let decodeDir = fun /* internal */
-| "ltr" => Ltr
-| "rtl" => Rtl
-| _     => Unknown;
+external window : window = "window" [@@bs.val];
+external document : document = "document" [@@bs.val];
+external history : history = "document.history" [@@bs.val];
+external location : location = "document.location" [@@bs.val];

--- a/src/dom/domTokenListRe.re
+++ b/src/dom/domTokenListRe.re
@@ -1,4 +1,4 @@
-  type t = DomRe.domTokenList;
+  type t = DomTypesRe.domTokenList;
 
   external contains : string => Js.boolean = "contains" [@@bs.send.pipe: t];
   let contains : string => t => bool = fun token self => Js.to_bool (contains token self);

--- a/src/dom/domTypesRe.re
+++ b/src/dom/domTypesRe.re
@@ -1,0 +1,61 @@
+type animation;
+type attr;
+type comment;
+type cssStyleDeclaration;
+type cssStyleSheet;
+type documentFragment;
+type documentImplementation;
+type documentType;
+type domRect;
+type domSettableTokenList;
+type domStringMap;
+type domTokenList;
+
+type node_like 'a;
+type node = node_like unit;
+type element_tag 'a;
+type element_like 'a = node_like (element_tag 'a);
+type element = element_like unit;
+type htmlElement_tag 'a;
+type htmlElement_like 'a = element_like (htmlElement_tag 'a);
+type htmlElement = htmlElement_like unit;
+type document_tag 'a;
+type document_like 'a = node_like (document_tag 'a);
+type document = document_like unit;
+type htmlDocument_tag;
+type htmlDocument = document_like htmlDocument_tag;
+
+type shadowRoot_tag;
+type shadowRoot = node_like shadowRoot_tag;
+
+type event;
+type eventTarget;
+type history;
+type htmlCollection;
+type location;
+type nodeFilter = {
+  acceptNode: element => int /* return type should be NodeFilter.action, but that would create a cycle */
+};
+type nodeIterator;
+type nodeList;
+type range;
+type selection;
+type textNode;
+type treeWalker;
+type window;
+
+/* special */
+type eventPointerId;
+
+type dir =
+| Ltr
+| Rtl
+| Unknown;
+let encodeDir = fun /* internal */
+| Ltr     => "ltr"
+| Rtl     => "rtl"
+| Unknown => "";
+let decodeDir = fun /* internal */
+| "ltr" => Ltr
+| "rtl" => Rtl
+| _     => Unknown;

--- a/src/dom/elementRe.re
+++ b/src/dom/elementRe.re
@@ -2,16 +2,16 @@ module Impl(Type: DomInternalRe.Type) => {
   type t_element = Type.t;
 
   /* Shouldn't be needed anymore
-  external asElement : t_element => DomRe.element = "%identity";
+  external asElement : t_element => DomTypesRe.element = "%identity";
   */
 
-  let asHtmlElement : t_element => Js.null DomRe.htmlElement = [%bs.raw {|
+  let asHtmlElement : t_element => Js.null DomTypesRe.htmlElement = [%bs.raw {|
     function (element) {
       // BEWARE: Assumes "contentEditable" uniquely identifies an HTMLELement
       return element.contentEditable !== undefined ?  element : null;
     }
   |}];
-  let asHtmlElement : t_element => option DomRe.htmlElement = fun self => Js.Null.to_opt (asHtmlElement self);
+  let asHtmlElement : t_element => option DomTypesRe.htmlElement = fun self => Js.Null.to_opt (asHtmlElement self);
 
   let ofNode node: option (t_element) =>
     (NodeRe.nodeType node) == Element ? Some (DomInternalRe.cast node) : None;
@@ -27,9 +27,9 @@ module Impl(Type: DomInternalRe.Type) => {
   | BeforeEnd   => "beforeemd"
   | AfterEnd    => "afterend";
 
-  external assignedSlot : t_element => DomRe.element = "" [@@bs.get]; /* experimental, returns HTMLSlotElement */
-  external attributes : t_element => array DomRe.attr = "" [@@bs.get]; /* return NameNodeMap, not array */
-  external classList : t_element => DomRe.domTokenList = "" [@@bs.get];
+  external assignedSlot : t_element => DomTypesRe.element = "" [@@bs.get]; /* experimental, returns HTMLSlotElement */
+  external attributes : t_element => array DomTypesRe.attr = "" [@@bs.get]; /* return NameNodeMap, not array */
+  external classList : t_element => DomTypesRe.domTokenList = "" [@@bs.get];
   external className : t_element => string = "" [@@bs.get];
   external setClassName : t_element => string => unit = "className" [@@bs.set];
   external clientHeight : t_element => int = "" [@@bs.get]; /* experimental */
@@ -43,56 +43,56 @@ module Impl(Type: DomInternalRe.Type) => {
   external localName : t_element => string = "" [@@bs.get];
   external namespaceURI : t_element => Js.null string = "" [@@bs.get];
   let namespaceURI : t_element => option string = fun self => Js.Null.to_opt (namespaceURI self);
-  external nextElementSibling : t_element => Js.null DomRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
-  let nextElementSibling : t_element => option DomRe.element = fun self => Js.Null.to_opt (nextElementSibling self);
+  external nextElementSibling : t_element => Js.null DomTypesRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
+  let nextElementSibling : t_element => option DomTypesRe.element = fun self => Js.Null.to_opt (nextElementSibling self);
   external outerHTML : t_element => string = "" [@@bs.get]; /* experimental, but widely supported */
   external setOuterHTML : t_element => string => unit = "outerHTML" [@@bs.set]; /* experimental, but widely supported */
   external prefix : t_element => Js.null string = "" [@@bs.get];
   let prefix : t_element => option string = fun self => Js.Null.to_opt (prefix self);
-  external previousElementSibling : t_element => Js.null DomRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
-  let previousElementSibling : t_element => option DomRe.element = fun self => Js.Null.to_opt (previousElementSibling self);
+  external previousElementSibling : t_element => Js.null DomTypesRe.element = "" [@@bs.get]; /* strictly part of the NonDocumentTypeChildNode interface */
+  let previousElementSibling : t_element => option DomTypesRe.element = fun self => Js.Null.to_opt (previousElementSibling self);
   external scrollHeight : t_element => int = "" [@@bs.get]; /* experimental, but widely supported */
   external scrollLeft : t_element => int = "" [@@bs.get]; /* experimental */
   external setScrollLeft : t_element => int => unit = "scrollLeft" [@@bs.set]; /* experimental */
   external scrollTop : t_element => int = "" [@@bs.get]; /* experimental, but widely supported */
   external setScrollTop : t_element => int => unit = "scrollTop" [@@bs.set]; /* experimental, but widely supported */
   external scrollWidth : t_element => int = "" [@@bs.get]; /* experimental */
-  external shadowRoot : t_element => DomRe.element = "" [@@bs.get]; /* experimental */
+  external shadowRoot : t_element => DomTypesRe.element = "" [@@bs.get]; /* experimental */
   external slot : t_element => string = "" [@@bs.get]; /* experimental */
   external setSlot : t_element => string => unit = "slot" [@@bs.set]; /* experimental */
   external tagName : t_element => string = "" [@@bs.get];
 
-  external attachShadow : Js.t {..} => DomRe.shadowRoot  = "" [@@bs.send.pipe: t_element]; /* experimental */
-  external animate : Js.t {..} => Js.t {..} => DomRe.animation = "" [@@bs.send.pipe: t_element]; /* experimental */
-  external closest : string => DomRe.element = "" [@@bs.send.pipe: t_element]; /* experimental */
-  external createShadowRoot : DomRe.shadowRoot = "" [@@bs.send.pipe: t_element]; /* experimental AND deprecated (?!) */
+  external attachShadow : Js.t {..} => DomTypesRe.shadowRoot  = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external animate : Js.t {..} => Js.t {..} => DomTypesRe.animation = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external closest : string => DomTypesRe.element = "" [@@bs.send.pipe: t_element]; /* experimental */
+  external createShadowRoot : DomTypesRe.shadowRoot = "" [@@bs.send.pipe: t_element]; /* experimental AND deprecated (?!) */
   external getAttribute : string => Js.null string = "" [@@bs.send.pipe: t_element];
   let getAttribute : string => t_element => option string = fun name self => Js.Null.to_opt (getAttribute name self);
   external getAttributeNS : string => string => Js.null string = "" [@@bs.send.pipe: t_element];
   let getAttributeNS : string => string => t_element => option string = fun ns name self => Js.Null.to_opt (getAttributeNS ns name self);
-  external getBoundingClientRect : DomRe.domRect = "" [@@bs.send.pipe: t_element];
-  external getClientRects : array DomRe.domRect = "" [@@bs.send.pipe: t_element];
-  external getElementsByClassName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
-  external getElementsByTagName : string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
-  external getElementsByTagNameNS : string => string => DomRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external getBoundingClientRect : DomTypesRe.domRect = "" [@@bs.send.pipe: t_element];
+  external getClientRects : array DomTypesRe.domRect = "" [@@bs.send.pipe: t_element];
+  external getElementsByClassName : string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external getElementsByTagName : string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_element];
+  external getElementsByTagNameNS : string => string => DomTypesRe.htmlCollection = "" [@@bs.send.pipe: t_element];
   external hasAttribute : string => Js.boolean = "" [@@bs.send.pipe: t_element];
   let hasAttribute : string => t_element => bool = fun name self => Js.to_bool (hasAttribute name self);
   external hasAttributeNS : string => string => Js.boolean = "" [@@bs.send.pipe: t_element];
   let hasAttributeNS : string => string => t_element => bool = fun ns name self => Js.to_bool (hasAttributeNS ns name self);
   external hasAttributes : Js.boolean = "" [@@bs.send.pipe: t_element];
   let hasAttributes : t_element => bool = fun self => Js.to_bool (hasAttributes self);
-  external insertAdjacentElement : string /* insertPosition enum */ => DomRe.element_like 'a => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
-  let insertAdjacentElement : insertPosition => DomRe.element_like 'a => t_element => unit = fun position element self => insertAdjacentElement (encodeInsertPosition position) element self;
+  external insertAdjacentElement : string /* insertPosition enum */ => DomTypesRe.element_like 'a => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
+  let insertAdjacentElement : insertPosition => DomTypesRe.element_like 'a => t_element => unit = fun position element self => insertAdjacentElement (encodeInsertPosition position) element self;
   external insertAdjacentHTML : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
   let insertAdjacentHTML : insertPosition => string => t_element => unit = fun position text self => insertAdjacentHTML (encodeInsertPosition position) text self;
   external insertAdjacentText : string /* insertPosition enum */ => string => unit = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
   let insertAdjacentText : insertPosition => string => t_element => unit = fun position text self => insertAdjacentText (encodeInsertPosition position) text self;
   external matches : string => Js.boolean = "" [@@bs.send.pipe: t_element]; /* experimental, but widely supported */
   let matches : string => t_element => bool = fun selector self => Js.to_bool (matches selector self);
-  external querySelector : string => Js.null DomRe.element = "" [@@bs.send.pipe: t_element];
-  let querySelector : string => t_element => option DomRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
-  external querySelectorAll : string => DomRe.nodeList = "" [@@bs.send.pipe: t_element];
-  external releasePointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
+  external querySelector : string => Js.null DomTypesRe.element = "" [@@bs.send.pipe: t_element];
+  let querySelector : string => t_element => option DomTypesRe.element = fun selector self => Js.Null.to_opt (querySelector selector self);
+  external querySelectorAll : string => DomTypesRe.nodeList = "" [@@bs.send.pipe: t_element];
+  external releasePointerCapture : DomTypesRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
   external remove : unit = "" [@@bs.send.pipe: t_element]; /* experimental */
   external removeAttribute : string => unit = "" [@@bs.send.pipe: t_element];
   external removeAttributeNS : string => string => unit = "" [@@bs.send.pipe: t_element];
@@ -104,12 +104,12 @@ module Impl(Type: DomInternalRe.Type) => {
   external scrollIntoViewWithOptions : Js.t {..} => unit = "scrollIntoView" [@@bs.send.pipe: t_element]; /* experimental */
   external setAttribute : string => string => unit = "" [@@bs.send.pipe: t_element];
   external setAttributeNS : string => string => string => unit = "" [@@bs.send.pipe: t_element];
-  external setPointerCapture : DomRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
+  external setPointerCapture : DomTypesRe.eventPointerId => unit = "" [@@bs.send.pipe: t_element];
 
   /* GlobalEventHandlers interface */
   /* Not sure this should be exposed, since EventTarget seems like a better API */
 
-  external setOnClick : t_element => (DomRe.event => unit) => unit = "onclick" [@@bs.set]; /* should be MouseEvent */
+  external setOnClick : t_element => (DomTypesRe.event => unit) => unit = "onclick" [@@bs.set]; /* should be MouseEvent */
 };
 /* TODO: This doesnæt work. Why?
 module Tree (Type: DomInternalRe.Type) => {
@@ -118,9 +118,9 @@ module Tree (Type: DomInternalRe.Type) => {
   include Impl { type t = Type };
 };
 
-include Tree { type t = DomRe.element };
+include Tree { type t = DomTypesRe.element };
 */
 
-include NodeRe.Impl { type t = DomRe.element };
-include EventTargetRe.Impl { type t = DomRe.element };
-include Impl { type t = DomRe.element };
+include NodeRe.Impl { type t = DomTypesRe.element };
+include EventTargetRe.Impl { type t = DomTypesRe.element };
+include Impl { type t = DomTypesRe.element };

--- a/src/dom/eventRe.re
+++ b/src/dom/eventRe.re
@@ -1,5 +1,5 @@
-type t = DomRe.event;
-type pointerId = DomRe.eventPointerId;
+type t = DomTypesRe.event;
+type pointerId = DomTypesRe.eventPointerId;
 
 type eventPhase =
 | None
@@ -22,11 +22,11 @@ external makeWithOptions : string => Js.t {..} = "Event" [@@bs.new];
 external bubbles : t => Js.boolean = "" [@@bs.get];
 external cancelable : t => Js.boolean = "" [@@bs.get];
 external composed : t => Js.boolean = "" [@@bs.get];
-external currentTarget : t => DomRe.eventTarget = "" [@@bs.get];
+external currentTarget : t => DomTypesRe.eventTarget = "" [@@bs.get];
 external defaultPrevented : t => Js.boolean = "" [@@bs.get];
 external eventPhase : t => int /* eventPhase enum */ = "" [@@bs.get];
 let eventPhase : t => eventPhase = fun self => decodeEventPhase (eventPhase self);
-external target : t => DomRe.eventTarget = "" [@@bs.get];
+external target : t => DomTypesRe.eventTarget = "" [@@bs.get];
 external timeStamp : t => float = "" [@@bs.get];
 external type_ : t => string = "type" [@@bs.get];
 external isTrusted : t => Js.boolean = "" [@@bs.get];
@@ -97,8 +97,8 @@ external pageX : t => int = "" [@@bs.get]; /* experimental, but widely supported
 external pageY : t => int = "" [@@bs.get]; /* experimental, but widely supported */
 external region : t => Js.null string = "" [@@bs.get];
 let region : t => option string = fun event => Js.Null.to_opt (region event);
-external relatedTarget : t => Js.null DomRe.eventTarget = "" [@@bs.get];
-let relatedTarget : t => option DomRe.eventTarget = fun event => Js.Null.to_opt (relatedTarget event);
+external relatedTarget : t => Js.null DomTypesRe.eventTarget = "" [@@bs.get];
+let relatedTarget : t => option DomTypesRe.eventTarget = fun event => Js.Null.to_opt (relatedTarget event);
 external screenX : t => int = "" [@@bs.get];
 external screenY : t => int = "" [@@bs.get];
 /* shiftKey */

--- a/src/dom/eventTargetRe.re
+++ b/src/dom/eventTargetRe.re
@@ -1,17 +1,17 @@
 module Impl (Type: DomInternalRe.Type) => {
   type t_eventtarget = Type.t;
 
-  external asEventTarget : t_eventtarget => DomRe.eventTarget = "%identity";
+  external asEventTarget : t_eventtarget => DomTypesRe.eventTarget = "%identity";
 
-  external addEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
-  external addEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
-  external addEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget];
-  let addEventListenerUseCapture : string => (DomRe.event => unit) => t_eventtarget => unit = fun type_ listener self => addEventListenerUseCapture type_ listener Js.true_ self;
-  external removeEventListener : string => (DomRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
-  external removeEventListenerWithOptions : string => (DomRe.event => unit) => Js.t {..} => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
-  external removeEventListenerUseCapture : string => (DomRe.event => unit) => Js.boolean => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget];
-  let removeEventListenerUseCapture : string => (DomRe.event => unit) => t_eventtarget => unit = fun type_ listener self => removeEventListenerUseCapture type_ listener Js.true_ self;
-  external dispatchEvent : DomRe.event => Js.boolean = "" [@@bs.send.pipe: t_eventtarget];
+  external addEventListener : string => (DomTypesRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
+  external addEventListenerWithOptions : string => (DomTypesRe.event => unit) => Js.t {..} => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
+  external addEventListenerUseCapture : string => (DomTypesRe.event => unit) => Js.boolean => unit = "addEventListener" [@@bs.send.pipe: t_eventtarget];
+  let addEventListenerUseCapture : string => (DomTypesRe.event => unit) => t_eventtarget => unit = fun type_ listener self => addEventListenerUseCapture type_ listener Js.true_ self;
+  external removeEventListener : string => (DomTypesRe.event => unit) => unit = "" [@@bs.send.pipe: t_eventtarget];
+  external removeEventListenerWithOptions : string => (DomTypesRe.event => unit) => Js.t {..} => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget]; /* not widely supported */
+  external removeEventListenerUseCapture : string => (DomTypesRe.event => unit) => Js.boolean => unit = "removeEventListener" [@@bs.send.pipe: t_eventtarget];
+  let removeEventListenerUseCapture : string => (DomTypesRe.event => unit) => t_eventtarget => unit = fun type_ listener self => removeEventListenerUseCapture type_ listener Js.true_ self;
+  external dispatchEvent : DomTypesRe.event => Js.boolean = "" [@@bs.send.pipe: t_eventtarget];
 };
 
-include Impl { type t = DomRe.eventTarget };
+include Impl { type t = DomTypesRe.eventTarget };

--- a/src/dom/historyRe.re
+++ b/src/dom/historyRe.re
@@ -1,4 +1,4 @@
-type t = DomRe.history;
+type t = DomTypesRe.history;
 type state; /* TODO: should be "anything that can be serializable" apparently */
 
 external length : t => int = "" [@@bs.get];

--- a/src/dom/htmlCollectionRe.re
+++ b/src/dom/htmlCollectionRe.re
@@ -1,3 +1,3 @@
-type t = DomRe.htmlCollection;
+type t = DomTypesRe.htmlCollection;
 
-external toArray : t => array DomRe.element = "Array.prototype.slice.call" [@@bs.val];
+external toArray : t => array DomTypesRe.element = "Array.prototype.slice.call" [@@bs.val];

--- a/src/dom/htmlDocumentRe.re
+++ b/src/dom/htmlDocumentRe.re
@@ -25,39 +25,39 @@ module Impl (Type: DomInternalRe.Type) => {
   | "complete"    => Complete
   | _             => Unknown;
 
-  external activeElement : t_htmlDocument => Js.null DomRe.element = "" [@@bs.get];
-  let activeElement : t_htmlDocument => option DomRe.element = fun self => Js.Null.to_opt (activeElement self);
-  external body : t_htmlDocument => Js.null DomRe.element = "" [@@bs.get]; /* returns Js.null HTMLBodyElement */
-  let body : t_htmlDocument => option DomRe.element = fun self => Js.Null.to_opt (body self);
-  external setBody : t_htmlDocument => DomRe.element => unit = "body" [@@bs.set]; /* accepth HTMLBodyElement */
+  external activeElement : t_htmlDocument => Js.null DomTypesRe.element = "" [@@bs.get];
+  let activeElement : t_htmlDocument => option DomTypesRe.element = fun self => Js.Null.to_opt (activeElement self);
+  external body : t_htmlDocument => Js.null DomTypesRe.element = "" [@@bs.get]; /* returns Js.null HTMLBodyElement */
+  let body : t_htmlDocument => option DomTypesRe.element = fun self => Js.Null.to_opt (body self);
+  external setBody : t_htmlDocument => DomTypesRe.element => unit = "body" [@@bs.set]; /* accepth HTMLBodyElement */
   external cookie : t_htmlDocument => string = "" [@@bs.get];
   external setCookie : t_htmlDocument => string => unit = "cookie" [@@bs.set];
-  external defaultView : t_htmlDocument => Js.null DomRe.window = "" [@@bs.get];
-  let defautView : t_htmlDocument => option DomRe.window = fun self => Js.Null.to_opt (defaultView self);
+  external defaultView : t_htmlDocument => Js.null DomTypesRe.window = "" [@@bs.get];
+  let defautView : t_htmlDocument => option DomTypesRe.window = fun self => Js.Null.to_opt (defaultView self);
   external designMode : t_htmlDocument => string /* designMode enum */ = "" [@@bs.get];
   let designMode : t_htmlDocument => designMode = fun self => decodeDesignMode (designMode self);
   external setDesignMode : t_htmlDocument => string /* designMode enum */ => unit = "designMode" [@@bs.set];
   let setDesignMode : t_htmlDocument => designMode => unit = fun self value => setDesignMode self (encodeDesignMode value);
   external dir : t_htmlDocument => string /* dir enum */ = "" [@@bs.get];
-  let dir : t_htmlDocument => DomRe.dir = fun self => DomRe.decodeDir (dir self);
+  let dir : t_htmlDocument => DomTypesRe.dir = fun self => DomTypesRe.decodeDir (dir self);
   external setDir : t_htmlDocument => string /* dir enum */ => unit = "dir" [@@bs.set];
-  let setDir : t_htmlDocument => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
+  let setDir : t_htmlDocument => DomTypesRe.dir => unit = fun self value => setDir self (DomTypesRe.encodeDir value);
   external domain : t_htmlDocument => Js.null string = "" [@@bs.get];
   let domain : t_htmlDocument => option string = fun self => Js.Null.to_opt (domain self);
   external setDomain : t_htmlDocument => string => unit = "domain" [@@bs.set];
-  external embeds : t_htmlDocument => DomRe.nodeList = "" [@@bs.get];
-  external forms : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
-  external head : t_htmlDocument => DomRe.element = "" [@@bs.get]; /* returns HTMLHeadElement */
-  external images : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external embeds : t_htmlDocument => DomTypesRe.nodeList = "" [@@bs.get];
+  external forms : t_htmlDocument => DomTypesRe.htmlCollection = "" [@@bs.get];
+  external head : t_htmlDocument => DomTypesRe.element = "" [@@bs.get]; /* returns HTMLHeadElement */
+  external images : t_htmlDocument => DomTypesRe.htmlCollection = "" [@@bs.get];
   external lastModified : t_htmlDocument => string = "" [@@bs.get];
-  external links : t_htmlDocument => DomRe.nodeList = "" [@@bs.get];
-  external location : t_htmlDocument => DomRe.location = "" [@@bs.get];
+  external links : t_htmlDocument => DomTypesRe.nodeList = "" [@@bs.get];
+  external location : t_htmlDocument => DomTypesRe.location = "" [@@bs.get];
   external setLocation : t_htmlDocument => string => unit = "location" [@@bs.set];
-  external plugins : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external plugins : t_htmlDocument => DomTypesRe.htmlCollection = "" [@@bs.get];
   external readyState : t_htmlDocument => string /* enum */ = "" [@@bs.get];
   let readyState : t_htmlDocument => readyState = fun self => decodeReadyState (readyState self);
   external referrer : t_htmlDocument => string = "" [@@bs.get];
-  external scripts : t_htmlDocument => DomRe.htmlCollection = "" [@@bs.get];
+  external scripts : t_htmlDocument => DomTypesRe.htmlCollection = "" [@@bs.get];
   external title : t_htmlDocument => string = "" [@@bs.get];
   external setTitle : t_htmlDocument => string => unit = "title" [@@bs.set];
   external url : t_htmlDocument => string = "URL" [@@bs.get];
@@ -65,8 +65,8 @@ module Impl (Type: DomInternalRe.Type) => {
   external close : unit = "" [@@bs.send.pipe: t_htmlDocument];
   external execCommand : string => Js.boolean => Js.null string => Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
   let execCommand : string => bool => option string => t_htmlDocument => bool = fun command show value self => Js.to_bool (execCommand command (Js.Boolean.to_js_boolean show) (Js.Null.from_opt value) self);
-  external getElementsByName : string => DomRe.nodeList = "" [@@bs.send.pipe: t_htmlDocument];
-  external getSelection : DomRe.selection = "" [@@bs.send.pipe: t_htmlDocument];
+  external getElementsByName : string => DomTypesRe.nodeList = "" [@@bs.send.pipe: t_htmlDocument];
+  external getSelection : DomTypesRe.selection = "" [@@bs.send.pipe: t_htmlDocument];
   external hasFocus : Js.boolean = "" [@@bs.send.pipe: t_htmlDocument];
   let hasFocus : t_htmlDocument => bool = fun self => Js.to_bool (hasFocus self);
   external open_ : unit = "open" [@@bs.send.pipe: t_htmlDocument];
@@ -81,7 +81,7 @@ module Impl (Type: DomInternalRe.Type) => {
   external writeln : string => unit = "" [@@bs.send.pipe: t_htmlDocument];
 };
 
-include NodeRe.Impl { type t = DomRe.htmlDocument };
-include EventTargetRe.Impl { type t = DomRe.htmlDocument };
-include DocumentRe.Impl { type t = DomRe.htmlDocument };
-include Impl { type t = DomRe.htmlDocument };
+include NodeRe.Impl { type t = DomTypesRe.htmlDocument };
+include EventTargetRe.Impl { type t = DomTypesRe.htmlDocument };
+include DocumentRe.Impl { type t = DomTypesRe.htmlDocument };
+include Impl { type t = DomTypesRe.htmlDocument };

--- a/src/dom/htmlElementRe.re
+++ b/src/dom/htmlElementRe.re
@@ -29,18 +29,18 @@ module Impl (Type: DomInternalRe.Type) => {
   let setContentEditable : t_htmlElement => contentEditable => unit = fun  self value => setContentEditable self (encodeContentEditable value);
   external isContentEditable : t_htmlElement => Js.boolean = "" [@@bs.get];
   let isContentEditable : t_htmlElement => bool = fun self => Js.to_bool (isContentEditable self);
-  external contextMenu : t_htmlElement => DomRe.htmlElement = "" [@@bs.get]; /* returns HTMLMenuElement */
-  external setContextMenu : t_htmlElement => DomRe.htmlElement => unit = "contextMenu" [@@bs.set]; /* accepts and returns HTMLMenuElement */
-  external dataset : t_htmlElement => DomRe.domStringMap = "" [@@bs.get];
+  external contextMenu : t_htmlElement => DomTypesRe.htmlElement = "" [@@bs.get]; /* returns HTMLMenuElement */
+  external setContextMenu : t_htmlElement => DomTypesRe.htmlElement => unit = "contextMenu" [@@bs.set]; /* accepts and returns HTMLMenuElement */
+  external dataset : t_htmlElement => DomTypesRe.domStringMap = "" [@@bs.get];
   external dir : t_htmlElement => string /* enum */ = "" [@@bs.get];
-  let dir : t_htmlElement => DomRe.dir = fun self => DomRe.decodeDir (dir self);
+  let dir : t_htmlElement => DomTypesRe.dir = fun self => DomTypesRe.decodeDir (dir self);
   external setDir : t_htmlElement => string /* enum */ => unit = "dir" [@@bs.set];
-  let setDir : t_htmlElement => DomRe.dir => unit = fun self value => setDir self (DomRe.encodeDir value);
+  let setDir : t_htmlElement => DomTypesRe.dir => unit = fun self value => setDir self (DomTypesRe.encodeDir value);
   external draggable : t_htmlElement => Js.boolean = "" [@@bs.get];
   let draggable : t_htmlElement => bool = fun self => Js.to_bool (draggable self);
   external setDraggable : t_htmlElement => Js.boolean => unit = "draggable" [@@bs.set];
   let setDraggable : t_htmlElement => bool => unit = fun self value => setDraggable self (Js.Boolean.to_js_boolean value);
-  external dropzone : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get];
+  external dropzone : t_htmlElement => DomTypesRe.domSettableTokenList = "" [@@bs.get];
   external hidden : t_htmlElement => Js.boolean = "" [@@bs.get];
   let hidden : t_htmlElement => bool = fun self => Js.to_bool (hidden self);
   external setHidden : t_htmlElement => Js.boolean => unit = "hidden" [@@bs.set];
@@ -49,11 +49,11 @@ module Impl (Type: DomInternalRe.Type) => {
   let itemScope : t_htmlElement => bool = fun self => Js.to_bool (itemScope self);
   external setItemScope : t_htmlElement => Js.boolean => unit = "itemScope" [@@bs.set]; /* experimental */
   let setItemScope : t_htmlElement => bool => unit = fun self value => setItemScope self (Js.Boolean.to_js_boolean value);
-  external itemType : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemType : t_htmlElement => DomTypesRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
   external itemId : t_htmlElement => string = "" [@@bs.get]; /* experimental */
   external setItemId : t_htmlElement => string => unit = "itemId" [@@bs.set]; /* experimental */
-  external itemRef : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
-  external itemProp : t_htmlElement => DomRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemRef : t_htmlElement => DomTypesRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
+  external itemProp : t_htmlElement => DomTypesRe.domSettableTokenList = "" [@@bs.get]; /* experimental */
   external itemValue : t_htmlElement => Js.t {..} = "" [@@bs.get]; /* experimental */
   external setItemValue : t_htmlElement => Js.t {..} => unit = "itemValue" [@@bs.set]; /* experimental */
   external lang : t_htmlElement => string = "" [@@bs.get];
@@ -68,8 +68,8 @@ module Impl (Type: DomInternalRe.Type) => {
   let spellcheck : t_htmlElement => bool = fun self => Js.to_bool (spellcheck self);
   external setSpellcheck : t_htmlElement => Js.boolean => unit = "spellcheck" [@@bs.set];
   let setSpellcheck : t_htmlElement => bool => unit = fun self value => setSpellcheck self (Js.Boolean.to_js_boolean value);
-  external style : t_htmlElement => DomRe.cssStyleDeclaration = "" [@@bs.get];
-  external setStyle : t_htmlElement => DomRe.cssStyleDeclaration => unit = "style" [@@bs.set];
+  external style : t_htmlElement => DomTypesRe.cssStyleDeclaration = "" [@@bs.get];
+  external setStyle : t_htmlElement => DomTypesRe.cssStyleDeclaration => unit = "style" [@@bs.set];
   external tabIndex : t_htmlElement => int = "" [@@bs.get];
   external setTabIndex : t_htmlElement => int => unit = "tabIndex" [@@bs.set];
   external title : t_htmlElement => string = "" [@@bs.get];
@@ -103,10 +103,10 @@ module Tree (Type: DomInternalRe.Type) => {
   include Impl { type t = Type };
 };
 
-include Tree { type t = DomRe.htmlElement };
+include Tree { type t = DomTypesRe.htmlElement };
 */
 
-include NodeRe.Impl { type t = DomRe.htmlElement };
-include EventTargetRe.Impl { type t = DomRe.htmlElement };
-include ElementRe.Impl { type t = DomRe.htmlElement };
-include Impl { type t = DomRe.htmlElement };
+include NodeRe.Impl { type t = DomTypesRe.htmlElement };
+include EventTargetRe.Impl { type t = DomTypesRe.htmlElement };
+include ElementRe.Impl { type t = DomTypesRe.htmlElement };
+include Impl { type t = DomTypesRe.htmlElement };

--- a/src/dom/locationRe.re
+++ b/src/dom/locationRe.re
@@ -1,4 +1,4 @@
-type t = DomRe.location;
+type t = DomTypesRe.location;
 
 /* a more ergonomic API would perhaps accept a Window.t directly instead of Location.t */
 

--- a/src/dom/nodeFilterRe.re
+++ b/src/dom/nodeFilterRe.re
@@ -1,4 +1,4 @@
-type t = DomRe.nodeFilter;
+type t = DomTypesRe.nodeFilter;
 
 let make f: t => {
   acceptNode: f

--- a/src/dom/nodeListRe.re
+++ b/src/dom/nodeListRe.re
@@ -1,3 +1,3 @@
-type t = DomRe.nodeList;
+type t = DomTypesRe.nodeList;
 
-external toArray : t => array DomRe.node = "Array.prototype.slice.call" [@@bs.val];
+external toArray : t => array DomTypesRe.node = "Array.prototype.slice.call" [@@bs.val];

--- a/src/dom/nodeRe.re
+++ b/src/dom/nodeRe.re
@@ -31,19 +31,19 @@ module Impl (Type: DomInternalRe.Type) => {
   |  _ => Unknown;
 
   /* Shouldn't be needed anymore
-  external asNode : t_node => DomRe.node = "%identity";
+  external asNode : t_node => DomTypesRe.node = "%identity";
   */
 
   /* baseURI */
-  external childNodes : t_node => DomRe.nodeList  = "" [@@bs.get];
-  external firstChild : t_node => Js.null DomRe.node = "" [@@bs.get];
-  let firstChild : t_node => option DomRe.node = fun self => Js.Null.to_opt (firstChild self);
+  external childNodes : t_node => DomTypesRe.nodeList  = "" [@@bs.get];
+  external firstChild : t_node => Js.null DomTypesRe.node = "" [@@bs.get];
+  let firstChild : t_node => option DomTypesRe.node = fun self => Js.Null.to_opt (firstChild self);
   external innerText : t_node => string = "" [@@bs.get];
   external setInnerText : t_node => string => unit = "innerText" [@@bs.set];
-  external lastChild : t_node => Js.null DomRe.node = "" [@@bs.get];
-  let lastChild : t_node => option DomRe.node = fun self => Js.Null.to_opt (lastChild self);
-  external nextSibling : t_node => Js.null DomRe.node = "" [@@bs.get];
-  let nextSibling : t_node => option DomRe.node = fun self => Js.Null.to_opt (nextSibling self);
+  external lastChild : t_node => Js.null DomTypesRe.node = "" [@@bs.get];
+  let lastChild : t_node => option DomTypesRe.node = fun self => Js.Null.to_opt (lastChild self);
+  external nextSibling : t_node => Js.null DomTypesRe.node = "" [@@bs.get];
+  let nextSibling : t_node => option DomTypesRe.node = fun self => Js.Null.to_opt (nextSibling self);
   external nodeName : t_node => string = "" [@@bs.get];
   /* nodePrincipal */
   external nodeType : t_node => int /* nodeType enum */ = "" [@@bs.get];
@@ -53,43 +53,43 @@ module Impl (Type: DomInternalRe.Type) => {
   external setNodeValue : t_node => Js.null string => unit = "nodeValue" [@@bs.set];
   let setNodeValue : t_node => option string => unit = fun self value => setNodeValue self (Js.Null.from_opt value);
   /* outerText */
-  external ownerDocument : t_node => DomRe.document = "" [@@bs.get];
-  external parentElement : t_node => Js.null DomRe.element = "" [@@bs.get];
-  let parentElement : t_node => option DomRe.element = fun self => Js.Null.to_opt (parentElement self);
-  external parentNode : t_node => Js.null DomRe.node = "" [@@bs.get];
-  let parentNode : t_node => option DomRe.node = fun self => Js.Null.to_opt (parentNode self);
-  external previousSibling : t_node => Js.null DomRe.node = "" [@@bs.get];
-  let previousSibling : t_node => option DomRe.node = fun self => Js.Null.to_opt (previousSibling self);
-  external rootNode : t_node => DomRe.node = "" [@@bs.get];
+  external ownerDocument : t_node => DomTypesRe.document = "" [@@bs.get];
+  external parentElement : t_node => Js.null DomTypesRe.element = "" [@@bs.get];
+  let parentElement : t_node => option DomTypesRe.element = fun self => Js.Null.to_opt (parentElement self);
+  external parentNode : t_node => Js.null DomTypesRe.node = "" [@@bs.get];
+  let parentNode : t_node => option DomTypesRe.node = fun self => Js.Null.to_opt (parentNode self);
+  external previousSibling : t_node => Js.null DomTypesRe.node = "" [@@bs.get];
+  let previousSibling : t_node => option DomTypesRe.node = fun self => Js.Null.to_opt (previousSibling self);
+  external rootNode : t_node => DomTypesRe.node = "" [@@bs.get];
   external textContent : t_node => string = "" [@@bs.get];
   external setTextContent : t_node => string => unit = "textContent" [@@bs.set];
 
-  external appendChild : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t_node];
-  external cloneNode : DomRe.node = "" [@@bs.send.pipe: t_node];
-  external cloneNodeDeep : Js.boolean => DomRe.node = "cloneNode" [@@bs.send.pipe: t_node];
-  let cloneNodeDeep : t_node => DomRe.node = fun self => cloneNodeDeep (Js.Boolean.to_js_boolean true) self;
-  external compareDocumentPosition : DomRe.node_like 'a => int = "" [@@bs.send.pipe: t_node]; /* returns a bitmask which could also be represeneted as an enum, see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition */
-  external contains : DomRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
-  let contains : DomRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (contains node self);
-  external getRootNode : DomRe.node = "" [@@bs.send.pipe: t_node];
-  external getRootNodeComposed : Js.boolean => DomRe.node = "getRootNode" [@@bs.send.pipe: t_node];
-  let getRootNodeComposed : t_node => DomRe.node = fun self => getRootNodeComposed (Js.Boolean.to_js_boolean true) self;
+  external appendChild : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t_node];
+  external cloneNode : DomTypesRe.node = "" [@@bs.send.pipe: t_node];
+  external cloneNodeDeep : Js.boolean => DomTypesRe.node = "cloneNode" [@@bs.send.pipe: t_node];
+  let cloneNodeDeep : t_node => DomTypesRe.node = fun self => cloneNodeDeep (Js.Boolean.to_js_boolean true) self;
+  external compareDocumentPosition : DomTypesRe.node_like 'a => int = "" [@@bs.send.pipe: t_node]; /* returns a bitmask which could also be represeneted as an enum, see https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition */
+  external contains : DomTypesRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let contains : DomTypesRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (contains node self);
+  external getRootNode : DomTypesRe.node = "" [@@bs.send.pipe: t_node];
+  external getRootNodeComposed : Js.boolean => DomTypesRe.node = "getRootNode" [@@bs.send.pipe: t_node];
+  let getRootNodeComposed : t_node => DomTypesRe.node = fun self => getRootNodeComposed (Js.Boolean.to_js_boolean true) self;
   external hasChildNodes : Js.boolean = "" [@@bs.send.pipe: t_node];
   let hasChildNodes : t_node => bool = fun self => Js.to_bool (hasChildNodes self);
-  external insertBefore : DomRe.node_like 'a => Js.null (DomRe.node_like 'b) => DomRe.node_like 'a = "" [@@bs.send.pipe: t_node];
-  let insertBefore : DomRe.node_like 'a => option (DomRe.node_like 'b) => t_node => DomRe.node_like 'a = fun node reference self => insertBefore node (Js.Null.from_opt reference) self;
+  external insertBefore : DomTypesRe.node_like 'a => Js.null (DomTypesRe.node_like 'b) => DomTypesRe.node_like 'a = "" [@@bs.send.pipe: t_node];
+  let insertBefore : DomTypesRe.node_like 'a => option (DomTypesRe.node_like 'b) => t_node => DomTypesRe.node_like 'a = fun node reference self => insertBefore node (Js.Null.from_opt reference) self;
   external isDefaultNamespace : string => Js.boolean = "" [@@bs.send.pipe: t_node];
   let isDefaultNamespace : string => t_node => bool = fun ns self => Js.to_bool (isDefaultNamespace ns self);
-  external isEqualNode : DomRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
-  let isEqualNode: DomRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (isEqualNode node self);
-  external isSameNode : DomRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
-  let isSameNode: DomRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (isSameNode node self);
+  external isEqualNode : DomTypesRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let isEqualNode: DomTypesRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (isEqualNode node self);
+  external isSameNode : DomTypesRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t_node];
+  let isSameNode: DomTypesRe.node_like 'a => t_node => bool = fun node self => Js.to_bool (isSameNode node self);
   external lookupNamespaceURI : Js.null string => Js.null string = "" [@@bs.send.pipe: t_node];
   let lookupNamespaceURI: option string => t_node => option string = fun prefix self => Js.Null.to_opt (lookupNamespaceURI (Js.Null.from_opt prefix) self);
   external lookupPrefix : string = "lookupPrefix" [@@bs.send.pipe: t_node];
   external normalize : unit = "" [@@bs.send.pipe: t_node];
-  external removeChild : DomRe.node_like 'a => DomRe.node_like 'a = "" [@@bs.send.pipe: t_node];
+  external removeChild : DomTypesRe.node_like 'a => DomTypesRe.node_like 'a = "" [@@bs.send.pipe: t_node];
   /* replacChild */
 };
 
-include Impl { type t = DomRe.node };
+include Impl { type t = DomTypesRe.node };

--- a/src/dom/rangeRe.re
+++ b/src/dom/rangeRe.re
@@ -1,4 +1,4 @@
-type t = DomRe.range;
+type t = DomTypesRe.range;
 
 type compareHow =
 | StartToStart
@@ -26,39 +26,39 @@ external make : unit => t = "Range" [@@bs.new]; /* experimental */
 
 external collapsed : t => Js.boolean = "" [@@bs.get];
 let collapsed : t => bool = fun self => Js.to_bool (collapsed self);
-external commonAncestorContainer : t => DomRe.node = "" [@@bs.get];
-external endContainer : t => DomRe.node = "" [@@bs.get];
+external commonAncestorContainer : t => DomTypesRe.node = "" [@@bs.get];
+external endContainer : t => DomTypesRe.node = "" [@@bs.get];
 external endOffset : t => int = "" [@@bs.get];
-external startContainer : t => DomRe.node = "" [@@bs.get];
+external startContainer : t => DomTypesRe.node = "" [@@bs.get];
 external startOffset : t => int = "" [@@bs.get];
 
-external setStart : DomRe.node_like 'a => int => unit = "" [@@bs.send.pipe: t];
-external setEnd : DomRe.node_like 'a => int => unit = "" [@@bs.send.pipe: t];
-external setStartBefore : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external setStartAfter : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external setEndBefore : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external setEndAfter : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external selectNode : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external selectNodeContents : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external setStart : DomTypesRe.node_like 'a => int => unit = "" [@@bs.send.pipe: t];
+external setEnd : DomTypesRe.node_like 'a => int => unit = "" [@@bs.send.pipe: t];
+external setStartBefore : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external setStartAfter : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external setEndBefore : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external setEndAfter : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external selectNode : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external selectNodeContents : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
 external collapse : unit = "" [@@bs.send.pipe: t];
 external collapseToStart : Js.boolean =>unit = "" [@@bs.send.pipe: t];
 let collapseToStart : t => unit = fun self => collapseToStart (Js.Boolean.to_js_boolean true) self;
-external cloneContents : DomRe.documentFragment = "" [@@bs.send.pipe: t];
+external cloneContents : DomTypesRe.documentFragment = "" [@@bs.send.pipe: t];
 external deleteContents : unit = "" [@@bs.send.pipe: t];
-external extractContents : DomRe.documentFragment = "" [@@bs.send.pipe: t];
-external insertNode : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
-external surroundContents : DomRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external extractContents : DomTypesRe.documentFragment = "" [@@bs.send.pipe: t];
+external insertNode : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
+external surroundContents : DomTypesRe.node_like 'a => unit = "" [@@bs.send.pipe: t];
 external compareBoundaryPoints : int /* compareHow enum */ => t => int /* compareResult enum */ = "" [@@bs.send.pipe: t];
 let compareBoundaryPoint : compareHow => t => t => compareResult = fun how range self => decodeCompareResult (compareBoundaryPoints (encodeCompareHow how) range self);
 external cloneRange : t = "" [@@bs.send.pipe: t];
 external detach : unit = "" [@@bs.send.pipe: t];
 external toString : string = "" [@@bs.send.pipe: t];
-external comparePoint : DomRe.node_like 'a => int => int /* compareRsult enum */ = "" [@@bs.send.pipe: t];
-let comparePoint : DomRe.node_like 'a => int => t => compareResult = fun node offset self => decodeCompareResult (comparePoint node offset self);
-external createContextualFragment : string => DomRe.documentFragment = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-external getBoundingClientRect : DomRe.domRect = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-external getClientRects : array DomRe.domRect = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
-external intersectsNode : DomRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t];
-let intersectsNode : DomRe.node_like 'a => t => bool = fun node self => Js.to_bool (intersectsNode node self);
-external isPointInRange : DomRe.node_like 'a => int => Js.boolean = "" [@@bs.send.pipe: t];
-let isPointInRange : DomRe.node_like 'a => int => t => bool = fun node offset self => Js.to_bool (isPointInRange node offset self);
+external comparePoint : DomTypesRe.node_like 'a => int => int /* compareRsult enum */ = "" [@@bs.send.pipe: t];
+let comparePoint : DomTypesRe.node_like 'a => int => t => compareResult = fun node offset self => decodeCompareResult (comparePoint node offset self);
+external createContextualFragment : string => DomTypesRe.documentFragment = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
+external getBoundingClientRect : DomTypesRe.domRect = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
+external getClientRects : array DomTypesRe.domRect = "" [@@bs.send.pipe: t]; /* experimental, but widely supported */
+external intersectsNode : DomTypesRe.node_like 'a => Js.boolean = "" [@@bs.send.pipe: t];
+let intersectsNode : DomTypesRe.node_like 'a => t => bool = fun node self => Js.to_bool (intersectsNode node self);
+external isPointInRange : DomTypesRe.node_like 'a => int => Js.boolean = "" [@@bs.send.pipe: t];
+let isPointInRange : DomTypesRe.node_like 'a => int => t => bool = fun node offset self => Js.to_bool (isPointInRange node offset self);

--- a/src/dom/selectionRe.re
+++ b/src/dom/selectionRe.re
@@ -1,22 +1,22 @@
-type t = DomRe.selection;
+type t = DomTypesRe.selection;
 
-external anchorNode : t => DomRe.node = "" [@@bs.get];
+external anchorNode : t => DomTypesRe.node = "" [@@bs.get];
 external anchorOffset : t => int = "" [@@bs.get];
-external focusNode : t => DomRe.node = "" [@@bs.get];
+external focusNode : t => DomTypesRe.node = "" [@@bs.get];
 external focusOffset : t => int = "" [@@bs.get];
 external isCollapsed : t => Js.boolean = "" [@@bs.get];
 external rangeCount : t => int = "" [@@bs.get];
 
-external getRangeAt : int => DomRe.range = "" [@@bs.send.pipe: t];
-external collapse : DomRe.node_like _ => int => unit = "" [@@bs.send.pipe: t];
-external extend : DomRe.node_like _ => int => unit = "" [@@bs.send.pipe: t];
+external getRangeAt : int => DomTypesRe.range = "" [@@bs.send.pipe: t];
+external collapse : DomTypesRe.node_like _ => int => unit = "" [@@bs.send.pipe: t];
+external extend : DomTypesRe.node_like _ => int => unit = "" [@@bs.send.pipe: t];
 external collapseToStart : unit = "" [@@bs.send.pipe: t];
 external collapseToEnd : unit = "" [@@bs.send.pipe: t];
-external selectAllChildren : DomRe.node_like _ => unit = "" [@@bs.send.pipe: t];
-external addRange : DomRe.range => unit = "" [@@bs.send.pipe: t];
-external removeRange : DomRe.range => unit = "" [@@bs.send.pipe: t];
+external selectAllChildren : DomTypesRe.node_like _ => unit = "" [@@bs.send.pipe: t];
+external addRange : DomTypesRe.range => unit = "" [@@bs.send.pipe: t];
+external removeRange : DomTypesRe.range => unit = "" [@@bs.send.pipe: t];
 external removeAllRanges : unit = "" [@@bs.send.pipe: t];
 external deleteFromDocument : unit = "" [@@bs.send.pipe: t];
 external toString : string = "" [@@bs.send.pipe: t];
-external containsNode : DomRe.node_like _ => Js.boolean => Js.boolean = "" [@@bs.send.pipe: t];
-let containsNode : DomRe.node_like _ => bool => t => bool = fun node partlyContained self => Js.to_bool (containsNode node (Js.Boolean.to_js_boolean partlyContained) self);
+external containsNode : DomTypesRe.node_like _ => Js.boolean => Js.boolean = "" [@@bs.send.pipe: t];
+let containsNode : DomTypesRe.node_like _ => bool => t => bool = fun node partlyContained self => Js.to_bool (containsNode node (Js.Boolean.to_js_boolean partlyContained) self);

--- a/src/dom/windowRe.re
+++ b/src/dom/windowRe.re
@@ -3,23 +3,23 @@ module Impl (Type: DomInternalRe.Type) => {
 
   /* This module is far from exhaustively implemented */
 
-  external document : t_window => DomRe.document = "" [@@bs.get];
+  external document : t_window => DomTypesRe.document = "" [@@bs.get];
   external fullScreen : t_window => Js.boolean = "" [@@bs.get];
   let fullScreen : t_window => bool = fun self => Js.to_bool (fullScreen self);
-  external history : t_window => DomRe.history = "" [@@bs.get];
+  external history : t_window => DomTypesRe.history = "" [@@bs.get];
   external innerWidth : t_window => int = "" [@@bs.get];
   external innerHeight : t_window => int = "" [@@bs.get];
-  external location : t_window => DomRe.location = "" [@@bs.get];
+  external location : t_window => DomTypesRe.location = "" [@@bs.get];
   external setLocation : t_window => string => unit = "location" [@@bs.set];
-  external parent : t_window => DomRe.window = "" [@@bs.get];
-  external top : t_window => DomRe.window = "" [@@bs.get];
+  external parent : t_window => DomTypesRe.window = "" [@@bs.get];
+  external top : t_window => DomTypesRe.window = "" [@@bs.get];
   external window : t_window => t_window = "" [@@bs.get]; /* This is really pointless I think, it's just here because window is the implicit global scope, and it's needed to be able to get a reference to it */
 
   external alert : string => unit = "" [@@bs.send.pipe: t_window];
   external confirm : string => Js.boolean = "" [@@bs.send.pipe: t_window];
   let confirm : string => t_window => bool = fun message self => Js.to_bool (confirm message self);
-  external getComputedStyle : DomRe.element => DomRe.cssStyleDeclaration = "" [@@bs.send.pipe: t_window];
-  external getComputedStyleWithPseudoElement : DomRe.element => string => DomRe.cssStyleDeclaration = "getComputedStyle" [@@bs.send.pipe: t_window];
+  external getComputedStyle : DomTypesRe.element => DomTypesRe.cssStyleDeclaration = "" [@@bs.send.pipe: t_window];
+  external getComputedStyleWithPseudoElement : DomTypesRe.element => string => DomTypesRe.cssStyleDeclaration = "getComputedStyle" [@@bs.send.pipe: t_window];
   external prompt : string => string = "" [@@bs.send.pipe: t_window];
   external promptWithDefault : string => string => string = "prompt" [@@bs.send.pipe: t_window];
   external scroll : int => int => unit = "" [@@bs.send.pipe: t_window];
@@ -27,5 +27,5 @@ module Impl (Type: DomInternalRe.Type) => {
   external setOnLoad : t_window => (unit => unit) => unit = "onload" [@@bs.set];
 };
 
-include EventTargetRe.Impl { type t = DomRe.window };
-include Impl { type t = DomRe.window };
+include EventTargetRe.Impl { type t = DomTypesRe.window };
+include Impl { type t = DomTypesRe.window };

--- a/src/reasonJs.re
+++ b/src/reasonJs.re
@@ -8,10 +8,14 @@ external clearTimeout : timeoutId => unit = "clearTimeout" [@@bs.val];
 
 external requestAnimationFrame : (unit => unit) => unit = "requestAnimationFrame" [@@bs.val];
 
-external window : DomRe.window = "window" [@@bs.val];
-external document : DomRe.document = "document" [@@bs.val];
-external history : DomRe.history = "document.history" [@@bs.val];
-external location : DomRe.location = "document.location" [@@bs.val];
+external window : DomRe.window = "window" [@@bs.val]
+[@@ocaml.deprecated "Please use Dom.window instead"];
+external document : DomRe.document = "document" [@@bs.val]
+[@@ocaml.deprecated "Please use Dom.document instead"];
+external history : DomRe.history = "document.history" [@@bs.val]
+[@@ocaml.deprecated "Please use Dom.history instead"];
+external location : DomRe.location = "document.location" [@@bs.val]
+[@@ocaml.deprecated "Please use Dom.location instead"];
 
 module Base64 = Base64Re;
 module Date = DateRe;
@@ -24,23 +28,40 @@ module RegExp = RegExpRe;
 module Dom = DomRe;
 
 /* TODO: Should be moved into Dom */
-module CssStyleDeclaration = CssStyleDeclarationRe;
-module Document = DocumentRe;
-module DomTokenList = DomTokenListRe;
-module Element = ElementRe;
-module Event = EventRe;
-module EventTarget = EventTargetRe;
-module History = HistoryRe;
-module HtmlCollection = HtmlCollectionRe;
-module HtmlDocument = HtmlDocumentRe;
-module HtmlElement = HtmlElementRe;
-module Location = LocationRe;
-module Node = NodeRe;
-module NodeFilter = NodeFilterRe;
-module NodeList = NodeListRe;
-module Range = RangeRe;
-module Selection = SelectionRe;
-module Window = WindowRe;
+module CssStyleDeclaration = CssStyleDeclarationRe
+[@@ocaml.deprecated "Please use Dom.CssStyleDeclaration instead"];
+module Document = DocumentRe
+[@@ocaml.deprecated "Please use Dom.Document instead"];
+module DomTokenList = DomTokenListRe
+[@@ocaml.deprecated "Please use Dom.DomTokenList instead"];
+module Element = ElementRe
+[@@ocaml.deprecated "Please use Dom.Element instead"];
+module Event = EventRe
+[@@ocaml.deprecated "Please use Dom.Event instead"];
+module EventTarget = EventTargetRe
+[@@ocaml.deprecated "Please use Dom.EventTarget instead"];
+module History = HistoryRe
+[@@ocaml.deprecated "Please use Dom.History instead"];
+module HtmlCollection = HtmlCollectionRe
+[@@ocaml.deprecated "Please use Dom.HtmlCollection instead"];
+module HtmlDocument = HtmlDocumentRe
+[@@ocaml.deprecated "Please use Dom.HtmlDocument instead"];
+module HtmlElement = HtmlElementRe
+[@@ocaml.deprecated "Please use Dom.HtmlElement instead"];
+module Location = LocationRe
+[@@ocaml.deprecated "Please use Dom.Location instead"];
+module Node = NodeRe
+[@@ocaml.deprecated "Please use Dom.Node instead"];
+module NodeFilter = NodeFilterRe
+[@@ocaml.deprecated "Please use Dom.NodeFilter instead"];
+module NodeList = NodeListRe
+[@@ocaml.deprecated "Please use Dom.NodeList instead"];
+module Range = RangeRe
+[@@ocaml.deprecated "Please use Dom.Range instead"];
+module Selection = SelectionRe
+[@@ocaml.deprecated "Please use Dom.Selection instead"];
+module Window = WindowRe
+[@@ocaml.deprecated "Please use Dom.Window instead"];
 
 module Fetch = FetchRe;
 

--- a/tests/dom/document_expected.js
+++ b/tests/dom/document_expected.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Curry        = require("bs-platform/lib/js/curry");
+var DomRe        = require("../../src/dom/domRe");
 var ReasonJs     = require("../../src/reasonJs");
 var DocumentRe   = require("../../src/dom/documentRe");
 var NodeFilterRe = require("../../src/dom/nodeFilterRe");

--- a/tests/dom/document_test.re
+++ b/tests/dom/document_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let el = document |> Document.createElement "strong";
 

--- a/tests/dom/element_expected.js
+++ b/tests/dom/element_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe     = require("../../src/dom/domRe");
 var ReasonJs  = require("../../src/reasonJs");
 var ElementRe = require("../../src/dom/elementRe");
 

--- a/tests/dom/element_test.re
+++ b/tests/dom/element_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let el = document |> Document.createElement "strong";
 let el2 = document |> Document.createElement "small";

--- a/tests/dom/eventTarget_expected.js
+++ b/tests/dom/eventTarget_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe         = require("../../src/dom/domRe");
 var ReasonJs      = require("../../src/reasonJs");
 var EventTargetRe = require("../../src/dom/eventTargetRe");
 

--- a/tests/dom/eventTarget_test.re
+++ b/tests/dom/eventTarget_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let target = document |> Document.createElement "strong" |> Element.asEventTarget;
 let event = Event.make "my-event";

--- a/tests/dom/event_expected.js
+++ b/tests/dom/event_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe    = require("../../src/dom/domRe");
 var EventRe  = require("../../src/dom/eventRe");
 var ReasonJs = require("../../src/reasonJs");
 

--- a/tests/dom/event_test.re
+++ b/tests/dom/event_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let event = Event.make "my-event";
 

--- a/tests/dom/history_expected.js
+++ b/tests/dom/history_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe     = require("../../src/dom/domRe");
 var ReasonJs  = require("../../src/reasonJs");
 var HistoryRe = require("../../src/dom/historyRe");
 

--- a/tests/dom/history_test.re
+++ b/tests/dom/history_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let _ = History.length history;
 let _ = History.scrollRestoration history;

--- a/tests/dom/htmlDocument_expected.js
+++ b/tests/dom/htmlDocument_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe          = require("../../src/dom/domRe");
 var ReasonJs       = require("../../src/reasonJs");
 var DocumentRe     = require("../../src/dom/documentRe");
 var TestHelpers    = require("../testHelpers");

--- a/tests/dom/htmlDocument_test.re
+++ b/tests/dom/htmlDocument_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let el = document |> Document.createElement "strong";
 let htmlDocument = document |> Document.asHtmlDocument |> TestHelpers.unsafelyUnwrapOption;

--- a/tests/dom/htmlElement_expected.js
+++ b/tests/dom/htmlElement_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe         = require("../../src/dom/domRe");
 var ReasonJs      = require("../../src/reasonJs");
 var ElementRe     = require("../../src/dom/elementRe");
 var TestHelpers   = require("../testHelpers");

--- a/tests/dom/htmlElement_test.re
+++ b/tests/dom/htmlElement_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let el = document
   |> Document.createElement "strong"

--- a/tests/dom/location_expected.js
+++ b/tests/dom/location_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe      = require("../../src/dom/domRe");
 var ReasonJs   = require("../../src/reasonJs");
 var LocationRe = require("../../src/dom/locationRe");
 

--- a/tests/dom/location_test.re
+++ b/tests/dom/location_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let _ = Location.href location;
 let _ = Location.setHref location "http://reason.ml";

--- a/tests/dom/node_expected.js
+++ b/tests/dom/node_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe    = require("../../src/dom/domRe");
 var NodeRe   = require("../../src/dom/nodeRe");
 var ReasonJs = require("../../src/reasonJs");
 

--- a/tests/dom/node_test.re
+++ b/tests/dom/node_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let node = document |> Document.createElement "strong" |> Element.rootNode;
 let node2 = document |> Document.createElement "small" |> Element.rootNode;

--- a/tests/dom/range_expected.js
+++ b/tests/dom/range_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe    = require("../../src/dom/domRe");
 var RangeRe  = require("../../src/dom/rangeRe");
 var ReasonJs = require("../../src/reasonJs");
 

--- a/tests/dom/range_test.re
+++ b/tests/dom/range_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let node = document
   |> Document.createElement "strong";

--- a/tests/dom/selection_expected.js
+++ b/tests/dom/selection_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe       = require("../../src/dom/domRe");
 var ReasonJs    = require("../../src/reasonJs");
 var DocumentRe  = require("../../src/dom/documentRe");
 var SelectionRe = require("../../src/dom/selectionRe");

--- a/tests/dom/selection_test.re
+++ b/tests/dom/selection_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let node = document
   |> Document.createElement "strong";

--- a/tests/dom/window_expected.js
+++ b/tests/dom/window_expected.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var DomRe    = require("../../src/dom/domRe");
 var ReasonJs = require("../../src/reasonJs");
 var WindowRe = require("../../src/dom/windowRe");
 

--- a/tests/dom/window_test.re
+++ b/tests/dom/window_test.re
@@ -1,4 +1,4 @@
-open ReasonJs;
+open ReasonJs.Dom;
 
 let el = document |> Document.createElement "strong";
 let event = document |> Document.createEvent "my-event";


### PR DESCRIPTION
- Moved types into separate `DomTypesRe` module, which is then included back into `DomRe` to avoid dependency cycles
- Deprecated old exports (though it seems like deprecating module aliases doesn't really do anything)