### PR TITLE
Fix FFI which return options

### DIFF
--- a/src/dom/nodes/htmlCollectionRe.re
+++ b/src/dom/nodes/htmlCollectionRe.re
@@ -3,5 +3,5 @@ type t = Dom.htmlCollection;
 external toArray : t => array Dom.element = "Array.prototype.slice.call" [@@bs.val];
 
 external length : t => int = "" [@@bs.get];
-external item : int => option Dom.element = "" [@@bs.send.pipe: t];
+external item : int => option Dom.element = "" [@@bs.send.pipe: t][@@bs.return null_undefined_to_opt];
 external namedItem : string => option Dom.element = "" [@@bs.send.pipe: t];


### PR DESCRIPTION
When retuning option from an `external` the attribute [@@bs.return null_undefined_to_opt] must be added.